### PR TITLE
feat: add compliance scanning and path tracing stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ssfm-ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pytest
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet test dotnet/DV8.Console.sln
+  container:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: registry.dv8
+          username: ${{ secrets.REG_USER }}
+          password: ${{ secrets.REG_PASS }}
+      - run: docker build -t registry.dv8/ssfm:${{ github.sha }} .
+      - run: docker push registry.dv8/ssfm:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+**/bin/
+**/obj/
+.vs/
+*.db

--- a/DV8_SPEC.md
+++ b/DV8_SPEC.md
@@ -1,0 +1,331 @@
+# DV8 Sovereign SD-WAN & Network Management
+
+## Developer Technical Specification (Build-Ready)
+
+## 0) Outcomes & non-negotiables
+
+* **Sovereignty:** All control/telemetry keys, logs, and ML artefacts remain under national jurisdiction.
+* **Post-Quantum by design:** ECC default; lattice KEM/signature profiles ready; HOAC™ switches under risk.
+* **Zero-Trust at the session grain:** Identity = biometric+geo+time (DBGID™). Decrypt nothing by default.
+* **Field-level confidentiality:** Per-field AEAD (SET™) + optional linguistic camouflage (LSO™).
+* **Tamper-evident audit:** Every sensitive action immutably anchored (LedgerProof™).
+* **Edge resilience:** Air-gap/low-bandwidth operability; offline capsules; A/B OTA with anti-rollback.
+
+---
+
+## 1) System architecture (runnable mental model)
+
+**Planes:**
+
+* **Management plane:** React/Next console, tablet field app. Auth via mTLS+DBGID; RBAC/ABAC; audit-only mode for regulators.
+* **Control plane:** Policy compiler → Capsule Control Plane (CCP™) → device/overlay drivers.
+* **Data plane:** SD-WAN forwarding (DPDK/XDP), IPsec/WireGuard overlays, PQC-agile KEX, QoS/FEC/AQM.
+
+**Core subsystems:**
+
+* **QuantumShield Crypto:** DBGID™ (biometric+geo+time KDF), SET™ (per-field AEAD), HOAC™ (ECC↔PQC), LSO™ (camouflage).
+* **AIC™ capsules:** SessionOracle™, EntropyGuard™, KeySurgeon™, VectorMind™; hot-pluggable, explainable, versioned.
+* **Telemetry & detection:** APE-CIR™ (entropy drift, geo velocity, behaviour vector) with hard/soft lockdowns via CCP™.
+* **Audit:** LedgerProof™ (permissioned chain), plus Elastic/Loki mirrors for search; export packs for ISO/PCI/SOC2.
+
+**Infra profile:**
+
+* **Kubernetes 1.27+** (Calico L3 policies), **Vault** (HSM/TPM backed), **MinIO** (S3-compatible sovereign object store), **Falco** (eBPF runtime), **OPA/Gatekeeper** (admission), **OpenTelemetry** (traces/metrics).
+
+---
+
+## 2) Northbound APIs (management, automation, audit)
+
+**Protocol set:** gRPC (control), REST (admin/3rd-party), WebSocket (streamed insights), OpenAPI 3.1 + protobuf.
+
+### 2.1 Policy & SD-WAN intent (gRPC)
+
+```proto
+// dv8/policy/v1/policy.proto
+syntax = "proto3";
+package dv8.policy.v1;
+
+message AppClass { string name=1; repeated string match_dpi=2; int32 priority=3; }
+message PathPref { string name=1; int32 max_latency_ms=2; float max_loss=3; int32 max_jitter_ms=4; }
+message SegmentPolicy {
+  string id=1; string tenant=2; repeated AppClass apps=3; repeated PathPref paths=4;
+  bool pqc_required=5; // force HOAC->PQC for this segment
+}
+service PolicyService {
+  rpc UpsertSegment(SegmentPolicy) returns (SegmentPolicy);
+  rpc GetSegmentById(Id) returns (SegmentPolicy);
+  rpc ListSegments(Tenant) returns (stream SegmentPolicy);
+}
+```
+
+### 2.2 QuantumShield envelope (REST)
+
+```http
+POST /v1/crypto/envelope/decrypt
+Headers:
+  X-DV8-DBGID: <hex>         ; biometric+geo+time KDF
+  X-Geo: lat,lon,alt         ; signed by device cert
+  X-Device-Cert: mTLS peer   ; hardware-bound
+Body: { "fields":[{"name":"passport_id","ciphertext":"...","iv":"..."}] }
+```
+
+Response returns **only** authorised fields; CCP gates per role/zone/risk.
+
+### 2.3 Capsule Control Plane (CCP) adjudication (gRPC)
+
+```proto
+// dv8/ccp/v1/ccp.proto
+message AdjudicationReq {
+  string capsule; string user; string device_id; string zone;
+  uint32 identity_score; uint32 risk_score; bool pqc_requested;
+}
+message AdjudicationRes { enum Decision {ALLOW=0; ESCALATE=1; LOCK=2; DENY=3;}
+  Decision decision=1; string reason=2; map<string,string> obligations=3; // e.g. "pqc":"on"
+}
+service CCP { rpc Adjudicate(AdjudicationReq) returns (AdjudicationRes); }
+```
+
+### 2.4 Audit export (REST)
+
+* `GET /v1/audit/bundle?case=<id>&format=pdf|json` → immutable, signed pack; regulator-safe redactions applied.
+
+---
+
+## 3) Southbound & device management (routers/switches)
+
+### 3.1 Protocols
+
+* **Zero-touch provisioning:** Secure bootstrap via mTLS + short-lived enrollment token + TPM attestation.
+* **Config/telemetry:** gNMI (OpenConfig + DV8 extensions), NETCONF/YANG (for legacy), SNMPv3 (read-only minimal).
+* **Streaming telemetry:** gNMI Subscribe + OTLP; device pushes APE-CIR features (latency/loss, entropy deltas, keystroke timing for local UI, geo deltas).
+* **Zero-touch configuration management:** Devices pull signed configuration templates from the CCP at first boot; templates follow IETF and vendor best practices and can be versioned and atomically applied via gNMI/gNOI.
+
+### 3.2 DV8 YANG augment (extract)
+
+```yang
+module dv8-quantumshield {
+  namespace "urn:dv8:qs"; prefix qs;
+  container quantumshield {
+    leaf pqc-required { type boolean; default false; }
+    container dbg-id { leaf enabled { type boolean; default true; } }
+    list set-field { key "name"; leaf name { type string; }
+      leaf kdf { type enumeration { enum DBGID; enum PBKDF2; } }
+      leaf aead { type enumeration { enum AES256_GCM; } }
+    }
+    container lso { leaf enabled { type boolean; default false; } }
+  }
+}
+```
+
+### 3.3 Sandboxed device simulation
+
+For development and offline testing the console exposes an in-memory
+sandbox where virtual routers and switches can be registered with a
+dynamic number of network ports, warning lights and status fields. The
+sandbox API supports registering devices, updating their state and
+retrieving aggregate summaries such as total ports or active warnings.
+
+---
+
+## 4) Cryptography wiring (implementable details)
+
+### 4.1 Key hierarchy & flows
+
+* **Root of trust:** Device TPM/TEE + manufacturer root + DV8 intermediate; secure boot verified chain.
+* **Session seed:** `DBGID = SHA-512(biometric_hash || geohash || timestamp)`; derive ephemeral keys via HKDF.
+* **Per-field AEAD (SET™):** Unique key+IV per field; AAD binds tenant, role, and ledger pointer.
+* **Transport:** TLS 1.3 mTLS everywhere; Control-plane supports **hybrid KEX** (X25519+Kyber/ML-KEM) profile; data-plane IPsec IKEv2 or WireGuard with PQC-hybrid PSK overlay option.
+* **Agility (HOAC™):** ECC by default → switch to NTRU/ML-KEM on CCP mandate (risk>threshold, hostile zone, or policy `pqc-required=true`).
+* **Camouflage (LSO™):** Optional wrapper on exported artefacts (e.g., regulator packs, offline bundles) to defeat classifier-based interdiction; never weakens AEAD.
+
+### 4.2 Reference pseudocode (concise)
+
+**DBGID → SET™ helper (Go)**
+
+```go
+func DeriveDBGID(bio, geo []byte, ts time.Time) []byte {
+    h := sha512.New()
+    h.Write(bio); h.Write(geo); binary.Write(h, binary.BigEndian, ts.Unix())
+    return h.Sum(nil) // 64 bytes
+}
+func EncryptField(val []byte, dbgid []byte) (ct, iv, tag []byte) {
+    salt := hkdf.Extract(sha256.New, dbgid, []byte("dv8:set:v1"))
+    key := hkdf.Expand(sha256.New, salt, []byte("field-key"))[:32]
+    iv  := randBytes(12)
+    ct  := aesgcm(key).Seal(nil, iv, val, []byte("tenant|role|ledger"))
+    return ct, iv, nil
+}
+```
+
+**HOAC switch (Rust, sketch)**
+
+```rust
+fn kex(session: &Context, risk: u32) -> Secret {
+  if risk >= RISK_PQC || session.policy.pqc_required { return ntru_kem(); }
+  else { return ecdh_p521(); }
+}
+```
+
+---
+
+## 5) SD-WAN dataplane & path control
+
+* **Path selection:** Multi-metric (latency/jitter/loss/cost) with **risk bias**: `score = f(qos, APE-CIR risk, entropy drift, geo trust)`.
+* **App-aware steering:** DPI signatures + SNI/QUIC hints; privacy-sensitive classes are **LSO-eligible** and **PQC-preferred**.
+* **Reliability:** Per-class FEC, BBR/CC tuning, active probing; brownout mode for constrained uplinks.
+* **Segments:** Overlay VRFs per tenant/zone; micro-segmentation enforced by Calico + device ACLs synced from CCP.
+
+---
+
+## 6) Firmware & hardware (sovereign control)
+
+### 6.1 Platform stack
+
+* **Boot:** ROM → Verified bootloader → Measured kernel → Read-only base FS; A/B **OTA** images; anti-rollback fuses; SBOM attached.
+* **OS:** Hardened Linux LTS, musl-based userspace; DPDK for high-TPS routers; eBPF/XDP for L4 filtering/telemetry.
+* **Crypto modules:** FIPS-friendly boundary around AEAD/KEM/PRNG; self-tests on boot (KATs); zeroise on fault.
+* **Accel:** AES-NI/ARMv8 CryptoExt; PQC via CPU (initial) with future NPU offload hooks.
+* **Update channel:** Capsule-validated OTA package (signature + policy); **offline** via USB/sat bundle; LedgerProof writes provenance.
+
+### 6.2 Device services
+
+* **gnmid / netconfd / telemetryd / ccpgate / aic-agent / ipsec-mgr / route-orchestrator / ota-agent** — each as supervised units with health probes and signed images.
+
+---
+
+## 7) Data, storage, and schemas
+
+* **Config DB:** PostgreSQL (strong consistency); CRDT-based edge cache for offline branches.
+* **Events & time-series:** Loki (logs), VictoriaMetrics/Prom (metrics), Elastic (searchable audit mirrors).
+* **Objects:** MinIO with tenant buckets; WORM policy on immutable audit snapshots.
+* **Ledger:** Hyperledger Fabric (permissioned), channel per tenant; hash pointers referenced in app AAD.
+
+---
+
+## 8) Security controls & governance (operators’ run-book)
+
+* **ZTA:** All requests adjudicated by CCP; least-privilege scopes; tokens short-lived; device posture checks.
+* **Secrets:** Vault; no secrets in images; envelope encryption via KMS; just-in-time decryption bounded by DBGID.
+* **Admission:** Gatekeeper policies (only signed images; drop CAP_*; read-only FS).
+* **Runtime:** Falco rules for process/file/syscall anomalies; auto-quarantine using CCP LOCK.
+* **Privacy:** SET™ tags with retention class; POPIA/GDPR erasure executes token revocation and field shredding; audit proves action.
+
+---
+
+## 9) Observability, AIOps, and APE-CIR loop
+
+* **OpenTelemetry** traces for every user/API/capsule action; **redaction at source** for PII.
+* **APE-CIR signals:** entropy_delta, geo_velocity, behaviour_vector → unified risk in [0..100]; thresholds drive ALLOW/ESCALATE/LOCK.
+* **Explainability:** Each capsule emits decision trace; console shows “why” chain for every lockdown or re-key.
+
+---
+
+## 10) SLOs & performance budgets (hard targets)
+
+* Control-plane decision (CCP): **p50 ≤ 1.5 ms**, p99 ≤ 10 ms.
+* Capsule inference (AIC): **≤ 3 ms** typical per capsule, ≤ 10 ms chained.
+* Per-field AEAD (SET): **≤ 2 ms** @ 1 KB field on router-class CPU.
+* PQC KEM (ML-KEM/NTRU) handshake: **≤ 6 ms** budgeted on edge CPU.
+* SD-WAN failover: **≤ 300 ms** detection, **≤ 1 s** re-route.
+* OTA package flash (A/B): **≤ 120 s**; always recoverable.
+
+---
+
+## 11) Test strategy (ship-stopper gates)
+
+**Crypto & protocol**
+
+* KATs for AES-GCM/HKDF/DRBG; HOAC switch tests; PQC interop (ML-KEM/NTRU).
+* IV uniqueness fuzz; misuse-resistant AEAD tests; TLS1.3 hybrid suites canary.
+
+**ZTA & CCP**
+
+* Red-team bypasses (geo-spoof, biometric drift, device swap).
+* Replay/forgery harness: same bio, different geo/time ⇒ must fail.
+
+**Firmware**
+
+* Secure boot break attempts; anti-rollback; SBOM attestation; fault-injection (brownout, flash errors).
+
+**SD-WAN**
+
+* Link impairment lab (loss/jitter/cost churn); policy conformance; app steer correctness.
+
+**Privacy & audit**
+
+* Erasure requests verify cryptographic shredding; ledger/audit bundle verification.
+
+**Chaos & resilience**
+
+* Capsule crash/latency injection; CCP degraded mode; offline operation + resync conflict resolution.
+
+---
+
+## 12) Compliance track (evidence-first)
+
+* **FIPS 140-3**: define crypto module boundary, roles/services, self-tests; lab pre-assessment artefacts in repo.
+* **ISO/IEC 27001 + 27701**: Annex-A control matrix mapped to components; SoA auto-export.
+* **PCI DSS 4.x (if in scope):** scope reduction via SET; section-10 logging satisfied by LedgerProof + syslog trails.
+* **POPIA/GDPR:** data maps, ROPA, DSR run-books; redaction proofs.
+
+---
+
+## 13) Developer scaffolding (repos & starters)
+
+```
+/platform
+  /console           # NextJS (RBAC, OTEL, dark mode, i18n)
+  /ccp               # Go/Rust PDP, gRPC, OPA policies
+  /crypto            # Go libs: dbgID, set, hoac, lso; C FFI for firmware
+  /aic               # Capsule SDK (Py/Go), SessionOracle, EntropyGuard, KeySurgeon
+  /device-agents     # gnmid, telemetryd, ota-agent (Rust/Go)
+  /sdwan             # path engine, dpi, qos, fec, ipsec/wg driver
+  /audit             # LedgerProof writer, export packs
+  /infra             # Helm charts, Gatekeeper, Falco rules, Calico policies
+```
+
+**Capsule SDK (Python)**
+
+```python
+class Capsule:
+    def features(self, session): ...
+    def infer(self, feats)->dict: ...
+    def obligations(self, result)->dict: ...
+# Example: EntropyGuard
+class EntropyGuard(Capsule):
+    TH=0.15
+    def infer(self, f): 
+        delta=abs(f['entropy_now']-f['entropy_base'])
+        return {"risk": min(100, int(100*delta/self.TH))}
+```
+
+**Makefile targets**
+
+```
+make dev          # run CCP, AIC, console with kind cluster
+make test         # all unit + fuzz
+make e2e          # spin SD-WAN sim, chaos tests
+make sbom         # generate attestations
+make release      # signed images, provenance
+```
+
+---
+
+## 14) Rollout plan (90-day)
+
+* **Weeks 1–3:** Repos/CI; CCP MVP; DBGID/SET libs; gNMI skeleton; Helm baseline.
+* **Weeks 4–6:** AIC capsules (SessionOracle, EntropyGuard); HOAC switch; SD-WAN path engine; console MVP.
+* **Weeks 7–9:** Firmware OTA A/B; secure boot chain; device agents; PQC canary channel.
+* **Weeks 10–12:** Full test harness; chaos runs; regulator audit bundle; pilot at 2 branches + 1 DC.
+
+**Exit criteria:** All SLOs met; PQC failover verified; audit bundle passes external read-only review; offline mode proven.
+
+---
+
+## 15) Threat simulations (what we break before adversaries try)
+
+* **Impossible travel:** same user at two geos inside 15 min → APE-CIR spikes; CCP LOCK; KeySurgeon rekeys on next session.
+* **Classifier interdiction:** traffic marked "confidential" through hostile ISP → HOAC→PQC enforced; LSO camouflage on control artefacts.
+* **Insider drift:** keystroke and decision speed anomaly for reviewer → capsule flags; CCP escalates to quorum approval.
+
+-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+dev: ## run controller + mock devices
+	docker compose -f dev/docker-compose.yaml up -d
+proto:
+	buf generate
+openapi:
+	npx @redocly/cli build-docs openapi.yaml -o dist/api.html
+e2e:
+	npx playwright test

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pytest
 
 ## C# Web API
 
-A lightweight ASP.NET Core service offers equivalent firmware and analytics endpoints.
+A lightweight ASP.NET Core service offers equivalent firmware, sandbox, and zero-touch endpoints.
 
 Run the API:
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,125 @@
-# DV8-SS-SD-WAN
+# DV8 Quantum Shield
+
+Prototype console for SD-WAN and router/switch management backed by SQLite with an audit log for all device operations.
+
+QuantumShield primitives are stubbed end-to-end. All privileged endpoints emit an `X-DV8-Decision` header and accept the `X-DV8-DBGID` credential, mirroring the production controller's adjudication flow.
+
+## Running the console
+
+```bash
+pip install -r requirements.txt
+# install .NET SDK 8.0 (Ubuntu example)
+apt-get update && apt-get install -y dotnet-sdk-8.0
+uvicorn app.main:app --reload
+```
+
+The dashboard is served at `http://localhost:8000/dashboard` and includes
+basic analytics such as average latency and device status counts.
+
+On startup the FastAPI application verifies that core dependencies are
+installed, failing fast if any required modules are missing. It also
+preloads the .NET SDK by running `dotnet --info`; if the SDK is
+unavailable the service will terminate on startup.
+
+State is persisted in a SQLite database via SQLAlchemy. Firmware, zero-touch, and sandbox modules share a unified device table and every mutation is recorded in an `audit_log` table for traceability.
+
+Discovery jobs can be started to automatically identify devices on the network:
+
+- `POST /discovery/jobs` to start a discovery job
+- `GET /discovery/jobs/{id}` to retrieve job status
+- `GET /discovery/candidates?tenant=acme` to list discovered candidates
+
+Firmware installations can be simulated via the API:
+
+- `POST /firmware/install` with JSON body `{ "device": "router-1", "version": "1.2.3" }`
+- `GET /firmware/{device}` to retrieve the installed version.
+
+### Sandboxed device simulation
+
+The API can track simulated routers or switches with configurable
+ports, warning lights and status.
+
+- `POST /sandbox/device` with JSON body
+  `{ "name": "sim-router", "device_type": "router", "ports": 8 }`
+- `PUT /sandbox/device/{name}` to update status and warning lights
+  (e.g. `{ "status": "down", "warnings": { "temperature": true } }`)
+- `GET /sandbox/summary` to retrieve aggregate counts of devices,
+  ports, statuses and active warnings.
+
+### Zero-touch configuration management
+
+Devices can enroll with a configuration template and mark when the template
+has been applied:
+
+- `POST /zero-touch/enroll` with `{ "name": "ztp-router", "template": "basic-router" }`
+- `POST /zero-touch/device/{name}/applied` to indicate a device finished
+  applying its template
+- `GET /zero-touch/device/{name}` or `/zero-touch/devices` to retrieve
+  enrolled devices and their application status
+
+### Auto-capture & vendor collectors
+
+Devices can auto-populate hostname, management IP and OS version using a
+serial number, and vendor-specific collectors are exposed for inventory and
+health telemetry:
+
+- `POST /v1/devices/autocapture` with `{ "serial": "ABC123" }`
+- `GET /v1/vendors/meraki/collectors`
+
+### Self-healing and zero-error runtime
+
+The console preloads all Python dependencies at startup and registers a
+zero-error middleware. Any unhandled exception is logged to the audit trail
+and returned as a generic error response. The companion ASP.NET Core API
+preloads its singleton services at launch and uses a global error-handling
+middleware to record unexpected failures and append the `X-DV8-Decision`
+header on every response.
+
+AI-driven self-healing can be triggered via:
+
+- `POST /self-heal` to automatically recover devices in the sandbox.
+
+### Compliance scanning and vulnerability watch
+
+The console can simulate compliance checks and vulnerability database
+syncs:
+
+- `POST /v1/compliance/scans` with `{ "profile": "DISA" }` to start a
+  scan
+- `GET /v1/compliance/results?profile=DISA&device=router-1` to retrieve
+  results
+- `POST /v1/vulnwatch/sync` to fetch CVE advisories
+- `GET /v1/vulnwatch/findings?device=router-1` to list vulnerabilities
+
+### SD-WAN path tracing and policy impact
+
+- `GET /v1/sdwan/pathtracer?src=a&dst=b` returns hop-by-hop metrics
+- `GET /v1/policy/impact?policyId=p1&before=old&after=new` shows policy
+  impact timelines
+
+## Testing
+
+```bash
+pytest
+```
+
+## C# Web API
+
+A lightweight ASP.NET Core service offers equivalent firmware and analytics endpoints.
+
+Run the API:
+
+```bash
+cd dotnet
+dotnet run --project src/DV8.Console
+```
+
+Run the .NET tests:
+
+```bash
+cd dotnet
+dotnet test
+```
+
+The ASP.NET Core service preloads its singleton services at launch to ensure
+required dependencies are available.

--- a/TECH_REQUIREMENTS.md
+++ b/TECH_REQUIREMENTS.md
@@ -1,0 +1,35 @@
+# DV8 SS Flow Management & Dv8-FlowOS – Technical Requirements
+
+## Functional
+- Start/stop discovery per site/tenant with CIDR scopes; passive-only mode supported.
+- Candidate classification with confidence scoring, vendor/model inference, capability map (gNMI/NETCONF).
+- One-click sandbox build from discovered graph; traffic models and failure injection.
+- Replace virtual with physical preserving intents, labels, ring; attestation required by default.
+- Brownfield adoption: generate "intent from running" diff and safe-apply plan.
+
+## Security
+- All discovery jobs require DBGID session and CCP decision; events anchored to LedgerProof.
+- Only SNMPv3 authPriv allowed; block v1/v2c.
+- Secrets/PII stored via SET™; no plaintext at rest; browser stores nothing.
+- HOAC: ECC default; PQC enforced on hostile zones or policy; posture surfaced in UI.
+
+## Performance & Scale
+- Controller processes ≥5k candidates/min per region; ingest ≥50k telemetry msgs/s.
+- Discovery active probes ≤100pps/site; per-device ≤5pps; auto-backoff on loss/jitter spikes.
+- Commit P95 ≤200 ms (10k nodes); drift MTTR ≤5 min; CCP p99 ≤10 ms.
+
+## Reliability
+- Discovery jobs idempotent; resume after controller failover.
+- A/B OTA with health gates; automatic rollback on capsule risk spike.
+- Components health-probed; graceful degradation to passive-only if probes blocked.
+
+## Compliance
+- ISO 27001 Annex A control mapping; PCI/POPIA export packs; audit trail verifiable (hash chain).
+- FIPS 140-3 module boundary documented for crypto paths (AES-GCM, KEM, RNG).
+
+## Testing
+- Unit: fingerprint parser, classifier, rate limiter, SET/DBGID helpers.
+- Integration: SNMPv3/NETCONF/gNMI lab devices; ICMP off scenarios; NAT/overlap IP.
+- E2E: sandbox→pilot→GA, virtual→physical swap, brownfield adoption.
+- Chaos: broker partition, vault seal/unseal, link flaps; ensure no probe storms.
+- Security: replay attempts, geo-spoof of discovery operator, SNMPv3 downgrade → must DENY.

--- a/app/analytics.py
+++ b/app/analytics.py
@@ -1,0 +1,17 @@
+from typing import List, Dict
+
+
+def average_latency(metrics: List[Dict[str, float]]) -> float:
+    """Return average latency from metric list."""
+    if not metrics:
+        return 0.0
+    return sum(m["latency_ms"] for m in metrics) / len(metrics)
+
+
+def device_status_count(metrics: List[Dict[str, float]]) -> Dict[str, int]:
+    """Count devices by status."""
+    counts: Dict[str, int] = {}
+    for m in metrics:
+        status = m.get("status", "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return counts

--- a/app/autocapture.py
+++ b/app/autocapture.py
@@ -1,0 +1,17 @@
+from sqlalchemy.orm import Session
+
+from .db import Device, AuditLog
+
+
+def auto_capture(db: Session, serial: str):
+    hostname = f"dev-{serial[-4:].lower()}"
+    mgmt_ip = "192.0.2.1"
+    os_version = "FlowOS 1.0"
+    device = db.query(Device).filter_by(name=hostname).first()
+    if not device:
+        device = Device(name=hostname)
+        db.add(device)
+        db.flush()
+    db.add(AuditLog(action="autocapture", entity="device", entity_id=device.id, details=serial))
+    db.commit()
+    return {"hostname": hostname, "mgmt_ip": mgmt_ip, "os": os_version}

--- a/app/collectors.py
+++ b/app/collectors.py
@@ -1,0 +1,12 @@
+VENDOR_COLLECTORS = {
+    "meraki": ["inventory", "health"],
+    "viptela": ["inventory", "health"],
+    "velocloud": ["inventory", "health"],
+    "prisma": ["inventory", "health"],
+    "fortimanager": ["inventory", "health"],
+    "aruba": ["inventory", "health"],
+}
+
+
+def list_collectors(vendor: str):
+    return VENDOR_COLLECTORS.get(vendor.lower(), [])

--- a/app/compliance.py
+++ b/app/compliance.py
@@ -1,0 +1,12 @@
+from typing import Dict, List
+from sqlalchemy.orm import Session
+from .db import AuditLog
+
+def start_scan(db: Session, profile: str, scope: Dict[str, str]) -> Dict[str, str]:
+    job_id = f"{profile}-scan"
+    db.add(AuditLog(action="compliance_scan", entity="profile", details=profile))
+    db.commit()
+    return {"job": job_id}
+
+def get_results(profile: str, device: str) -> Dict[str, str]:
+    return {"device": device, "profile": profile, "status": "pass"}

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Generator
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    create_engine,
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker, Session
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./dv8.db")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()
+
+
+class Device(Base):
+    __tablename__ = "devices"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    device_type = Column(String, default="unknown")
+    ports = Column(Integer, default=0)
+    status = Column(String, default="up")
+    firmware = relationship("Firmware", uselist=False, back_populates="device")
+    zero_touch = relationship("ZeroTouchConfig", uselist=False, back_populates="device")
+    warnings = relationship("Warning", back_populates="device", cascade="all, delete-orphan")
+
+
+class Firmware(Base):
+    __tablename__ = "firmware"
+    id = Column(Integer, primary_key=True)
+    device_id = Column(Integer, ForeignKey("devices.id"), unique=True)
+    version = Column(String, nullable=False)
+    device = relationship("Device", back_populates="firmware")
+
+
+class ZeroTouchConfig(Base):
+    __tablename__ = "zero_touch"
+    id = Column(Integer, primary_key=True)
+    device_id = Column(Integer, ForeignKey("devices.id"), unique=True)
+    template = Column(String, nullable=False)
+    applied = Column(Boolean, default=False)
+    device = relationship("Device", back_populates="zero_touch")
+
+
+class Warning(Base):
+    __tablename__ = "warnings"
+    id = Column(Integer, primary_key=True)
+    device_id = Column(Integer, ForeignKey("devices.id"))
+    name = Column(String, nullable=False)
+    active = Column(Boolean, default=True)
+    device = relationship("Device", back_populates="warnings")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+    id = Column(Integer, primary_key=True)
+    action = Column(String, nullable=False)
+    entity = Column(String, nullable=False)
+    entity_id = Column(Integer, nullable=True)
+    details = Column(String, nullable=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/discovery.py
+++ b/app/discovery.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+from uuid import uuid4
+
+jobs: Dict[str, Dict[str, object]] = {}
+candidates: List[Dict[str, object]] = []
+
+
+def start_job(tenant: str, scopes: List[str], cidrs: List[str], passive_only: bool) -> Dict[str, object]:
+    job_id = str(uuid4())
+    job = {
+        "id": job_id,
+        "tenant": tenant,
+        "scopes": scopes,
+        "cidrs": cidrs,
+        "status": "running",
+        "started_at": datetime.utcnow().isoformat() + "Z",
+        "passive_only": passive_only,
+    }
+    jobs[job_id] = job
+    return job
+
+
+def get_job(job_id: str) -> Dict[str, object] | None:
+    return jobs.get(job_id)
+
+
+def list_candidates(tenant: str) -> Dict[str, List[Dict[str, object]]]:
+    # In real system, filter by tenant; here return all
+    return {"items": candidates}

--- a/app/firmware.py
+++ b/app/firmware.py
@@ -1,0 +1,27 @@
+from sqlalchemy.orm import Session
+
+from .db import Device, Firmware, AuditLog
+
+
+def install(db: Session, device: str, version: str) -> str:
+    device_obj = db.query(Device).filter_by(name=device).first()
+    if not device_obj:
+        device_obj = Device(name=device)
+        db.add(device_obj)
+        db.flush()
+    fw = db.query(Firmware).filter_by(device_id=device_obj.id).first()
+    if fw:
+        fw.version = version
+    else:
+        fw = Firmware(device_id=device_obj.id, version=version)
+        db.add(fw)
+    db.add(AuditLog(action="install_firmware", entity="device", entity_id=device_obj.id, details=version))
+    db.commit()
+    return version
+
+
+def get_version(db: Session, device: str) -> str:
+    device_obj = db.query(Device).filter_by(name=device).first()
+    if not device_obj or not device_obj.firmware:
+        return ""
+    return device_obj.firmware.version

--- a/app/guardrail.py
+++ b/app/guardrail.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Dict
+from sqlalchemy.orm import Session
+from .db import AuditLog
+
+
+def lint(intent_yaml: str) -> Dict[str, object]:
+    ok = "policy" in intent_yaml
+    return {"valid": ok, "issues": [] if ok else ["missing policy"]}
+
+
+def approve(db: Session, change_id: str) -> Dict[str, str]:
+    db.add(AuditLog(action="guardrail_approve", entity="change", details=change_id))
+    db.commit()
+    return {"changeId": change_id, "status": "approved"}

--- a/app/healer.py
+++ b/app/healer.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+from typing import Dict, List, Optional
+from sqlalchemy.orm import Session
+from .db import AuditLog
+
+_playbooks: Dict[int, Dict[str, object]] = {}
+_incidents: Dict[int, Dict[str, object]] = {}
+
+
+def create_playbook(name: str, triggers: List[dict], steps: List[dict]) -> Dict[str, object]:
+    pid = len(_playbooks) + 1
+    playbook = {"id": pid, "name": name, "triggers": triggers, "steps": steps}
+    _playbooks[pid] = playbook
+    # automatically create open incident
+    _incidents[pid] = {"id": pid, "playbook_id": pid, "state": "open"}
+    return playbook
+
+
+def list_incidents(state: Optional[str] = None) -> List[Dict[str, object]]:
+    incidents = list(_incidents.values())
+    if state:
+        incidents = [i for i in incidents if i["state"] == state]
+    return incidents
+
+
+def execute_incident(db: Session, incident_id: int) -> Optional[Dict[str, object]]:
+    incident = _incidents.get(incident_id)
+    if not incident or incident["state"] != "open":
+        return None
+    incident["state"] = "closed"
+    db.add(AuditLog(action="auto_heal", entity="incident", entity_id=incident_id))
+    db.commit()
+    return incident

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,385 @@
+from fastapi import FastAPI, Request, HTTPException, Depends, Response, Query
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+import importlib
+import shutil
+import subprocess
+from typing import Dict, Optional, List
+from sqlalchemy.orm import Session
+
+from .analytics import average_latency, device_status_count
+from .firmware import install as fw_install, get_version as fw_get_version
+from .sandbox import register as sb_register, get as sb_get, update as sb_update, list_devices as sb_list, summary as sb_summary
+from .zero_touch import enroll as zt_enroll, get as zt_get, mark_applied as zt_mark, list_devices as zt_list
+from .discovery import start_job, get_job, list_candidates
+from .db import get_db, init_db, SessionLocal, AuditLog
+from .zero_error import init_zero_error
+from .self_heal import heal_devices
+from .healer import create_playbook, list_incidents, execute_incident
+from .guardrail import lint as gr_lint, approve as gr_approve
+from .synthetics import create_probe, get_results as syn_results
+from .planner import recommend as planner_recommend
+from .compliance import start_scan, get_results as compliance_results
+from .vulnwatch import sync as vuln_sync, findings as vuln_findings
+from .pathtracer import trace as path_trace
+from .policy_impact import timeline as policy_timeline
+from .autocapture import auto_capture
+from .collectors import list_collectors
+
+app = FastAPI(title="DV8 SD-WAN Console")
+templates = Jinja2Templates(directory="app/templates")
+
+REQUIRED_MODULES = ["fastapi", "jinja2", "pydantic", "sqlalchemy"]
+
+
+def check_dependencies() -> None:
+    missing = [m for m in REQUIRED_MODULES if importlib.util.find_spec(m) is None]
+    if missing:
+        raise RuntimeError(f"Missing dependencies: {', '.join(missing)}")
+    for m in REQUIRED_MODULES:
+        importlib.import_module(m)
+
+
+def preload_dotnet_sdk() -> None:
+    """Ensure the .NET SDK is available by running `dotnet --info`."""
+    if shutil.which("dotnet") is None:
+        raise RuntimeError("Missing dependency: dotnet SDK is not installed")
+    subprocess.run(["dotnet", "--info"], check=True, stdout=subprocess.DEVNULL)
+
+
+@app.on_event("startup")
+async def startup_check() -> None:
+    check_dependencies()
+    preload_dotnet_sdk()
+    init_db()
+    init_zero_error(app)
+
+
+@app.middleware("http")
+async def decision_header(request: Request, call_next):
+    response = await call_next(request)
+    if "X-DV8-Decision" not in response.headers:
+        response.headers["X-DV8-Decision"] = "ALLOW"
+    return response
+
+# Sample metrics; in real system, would come from devices
+device_metrics = [
+    {"device": "router-1", "latency_ms": 10.5, "status": "up"},
+    {"device": "switch-1", "latency_ms": 20.2, "status": "up"},
+    {"device": "router-2", "latency_ms": 35.0, "status": "down"},
+]
+
+
+@app.get("/metrics")
+async def metrics():
+    return {
+        "devices": device_metrics,
+        "average_latency": average_latency(device_metrics),
+        "status_counts": device_status_count(device_metrics),
+    }
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(request: Request):
+    data = {
+        "devices": device_metrics,
+        "avg_latency": average_latency(device_metrics),
+        "status_counts": device_status_count(device_metrics),
+    }
+    return templates.TemplateResponse("dashboard.html", {"request": request, "data": data})
+
+
+class InstallRequest(BaseModel):
+    device: str
+    version: str
+
+
+@app.post("/firmware/install")
+async def install_firmware(req: InstallRequest, db: Session = Depends(get_db)):
+    version = fw_install(db, req.device, req.version)
+    return {"device": req.device, "version": version}
+
+
+@app.get("/firmware/{device}")
+async def firmware_status(device: str, db: Session = Depends(get_db)):
+    return {"device": device, "version": fw_get_version(db, device)}
+
+
+class ZeroTouchRequest(BaseModel):
+    name: str
+    template: str
+
+
+@app.post("/zero-touch/enroll")
+async def enroll_device(req: ZeroTouchRequest, db: Session = Depends(get_db)):
+    return zt_enroll(db, req.name, req.template)
+
+
+@app.get("/zero-touch/device/{name}")
+async def get_zero_touch(name: str, db: Session = Depends(get_db)):
+    device = zt_get(db, name)
+    if not device:
+        raise HTTPException(status_code=404, detail="device not found")
+    return device
+
+
+@app.post("/zero-touch/device/{name}/applied")
+async def mark_applied(name: str, db: Session = Depends(get_db)):
+    device = zt_mark(db, name)
+    if not device:
+        raise HTTPException(status_code=404, detail="device not found")
+    return device
+
+
+@app.get("/zero-touch/devices")
+async def list_zero_touch_devices(db: Session = Depends(get_db)):
+    return zt_list(db)
+
+
+class SandboxDevice(BaseModel):
+    name: str
+    device_type: str
+    ports: int
+    status: str = "up"
+    warnings: Dict[str, bool] = {}
+
+
+class StatusUpdate(BaseModel):
+    status: Optional[str] = None
+    warnings: Optional[Dict[str, bool]] = None
+
+
+@app.post("/sandbox/device")
+async def register_device(dev: SandboxDevice, db: Session = Depends(get_db)):
+    return sb_register(db, dev.name, dev.device_type, dev.ports, dev.status, dev.warnings)
+
+
+@app.get("/sandbox/device/{name}")
+async def get_device(name: str, db: Session = Depends(get_db)):
+    device = sb_get(db, name)
+    if not device:
+        raise HTTPException(status_code=404, detail="device not found")
+    return device
+
+
+@app.put("/sandbox/device/{name}")
+async def update_device(name: str, update: StatusUpdate, db: Session = Depends(get_db)):
+    device = sb_update(db, name, update.status, update.warnings)
+    if not device:
+        raise HTTPException(status_code=404, detail="device not found")
+    return device
+
+
+@app.get("/sandbox/devices")
+async def list_devices(db: Session = Depends(get_db)):
+    return sb_list(db)
+
+
+@app.get("/sandbox/summary")
+async def sandbox_summary(db: Session = Depends(get_db)):
+    return sb_summary(db)
+
+
+class DiscoveryRequest(BaseModel):
+    tenant: str
+    scopes: List[str]
+    cidrs: Optional[List[str]] = None
+    passiveOnly: bool = False
+
+
+@app.post("/discovery/jobs", status_code=202)
+async def start_discovery(req: DiscoveryRequest):
+    job = start_job(req.tenant, req.scopes, req.cidrs or [], req.passiveOnly)
+    return job
+
+
+@app.get("/discovery/jobs/{job_id}")
+async def get_discovery_job(job_id: str):
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job not found")
+    return job
+
+
+@app.get("/discovery/candidates")
+async def discovery_candidates(tenant: str):
+    return list_candidates(tenant)
+
+
+class ReplaceRequest(BaseModel):
+    serial: str
+    site: str
+    requireAttestation: bool = True
+
+
+@app.post("/devices/{virtual_id}:replace")
+async def replace_virtual(virtual_id: str, req: ReplaceRequest):
+    # Stub implementation; real system would verify attestation and swap state
+    return {"physicalId": req.serial, "ledger": "ledger-placeholder"}
+
+
+class CCPRequest(BaseModel):
+    actor: str
+    action: str
+    context: Dict[str, Optional[str]]
+
+
+@app.post("/v1/ccp/adjudications")
+async def ccp_adjudicate(req: CCPRequest):
+    return {"decision": "ALLOW", "reason": "stub"}
+
+
+class HoacRequest(BaseModel):
+    channel: str
+    policy: str
+    risk: int
+
+
+@app.post("/v1/crypto/hoac/negotiate")
+async def hoac_negotiate(req: HoacRequest):
+    return {"profile": "ECC", "transcript": ""}
+
+
+class AuditRequest(BaseModel):
+    lso: bool = False
+    scope: Optional[Dict[str, str]] = None
+
+
+@app.post("/v1/audit/bundles", status_code=201)
+async def create_audit_bundle(req: AuditRequest, response: Response):
+    response.headers["Location"] = "/audit/bundles/placeholder"
+    return {"status": "created"}
+
+@app.post("/self-heal")
+async def trigger_self_heal():
+    return {"healed": heal_devices()}
+
+
+# ----- Auto-Healer APIs -----
+
+class Playbook(BaseModel):
+    name: str
+    triggers: List[Dict[str, object]]
+    steps: List[Dict[str, object]]
+
+
+@app.post("/v1/heal/playbooks")
+async def create_heal_playbook(pb: Playbook):
+    return create_playbook(pb.name, pb.triggers, pb.steps)
+
+
+@app.get("/v1/heal/incidents")
+async def get_incidents(state: Optional[str] = Query(None)):
+    return list_incidents(state)
+
+
+@app.post("/v1/heal/incidents/{incident_id}/execute")
+async def execute_heal_incident(incident_id: int, db: Session = Depends(get_db)):
+    incident = execute_incident(db, incident_id)
+    if not incident:
+        raise HTTPException(status_code=404, detail="incident not found")
+    return incident
+
+
+# ----- GuardRail APIs -----
+
+class LintRequestModel(BaseModel):
+    intentYaml: str
+
+
+@app.post("/v1/guardrail/lint")
+async def guardrail_lint(req: LintRequestModel):
+    return gr_lint(req.intentYaml)
+
+
+class ApproveRequest(BaseModel):
+    changeId: str
+
+
+@app.post("/v1/guardrail/approve")
+async def guardrail_approve(req: ApproveRequest, db: Session = Depends(get_db)):
+    return gr_approve(db, req.changeId)
+
+
+# ----- Synthetics APIs -----
+
+class ProbeRequest(BaseModel):
+    intentId: str
+    endpoints: List[str]
+    proto: str
+    interval: int
+
+
+@app.post("/v1/synthetics/probes")
+async def create_probe_endpoint(req: ProbeRequest):
+    return create_probe(req.intentId, req.endpoints, req.proto, req.interval)
+
+
+@app.get("/v1/synthetics/results")
+async def synthetic_results(intentId: str):
+    return syn_results(intentId)
+
+
+# ----- Planner API -----
+
+class PlanRequest(BaseModel):
+    site: str
+    intentId: str
+    horizonDays: int
+
+
+@app.post("/v1/planner/recommend")
+async def planner_recommend_endpoint(req: PlanRequest):
+    return planner_recommend(req.site, req.intentId, req.horizonDays)
+
+
+# ----- Compliance & Vulnerability APIs -----
+
+class ComplianceScanRequest(BaseModel):
+    profile: str
+    scope: Dict[str, str] = {}
+
+
+@app.post("/v1/compliance/scans")
+async def compliance_scan(req: ComplianceScanRequest, db: Session = Depends(get_db)):
+    return start_scan(db, req.profile, req.scope)
+
+
+@app.get("/v1/compliance/results")
+async def compliance_scan_results(profile: str, device: str):
+    return compliance_results(profile, device)
+
+
+@app.post("/v1/vulnwatch/sync")
+async def vulnwatch_sync(db: Session = Depends(get_db)):
+    return vuln_sync(db)
+
+
+@app.get("/v1/vulnwatch/findings")
+async def vulnwatch_findings(device: str):
+    return vuln_findings(device)
+
+
+@app.get("/v1/sdwan/pathtracer")
+async def sdwan_pathtracer(src: str, dst: str):
+    return path_trace(src, dst)
+
+
+@app.get("/v1/policy/impact")
+async def policy_impact(policyId: str, before: str, after: str):
+    return policy_timeline(policyId, before, after)
+
+
+class AutoCaptureRequest(BaseModel):
+    serial: str
+
+
+@app.post("/v1/devices/autocapture")
+async def devices_autocapture(req: AutoCaptureRequest, db: Session = Depends(get_db)):
+    return auto_capture(db, req.serial)
+
+
+@app.get("/v1/vendors/{vendor}/collectors")
+async def vendor_collectors(vendor: str):
+    return {"collectors": list_collectors(vendor)}

--- a/app/pathtracer.py
+++ b/app/pathtracer.py
@@ -1,0 +1,8 @@
+from typing import Dict, List
+
+def trace(src: str, dst: str) -> Dict[str, List[Dict[str, int]]]:
+    hops = [
+        {"hop": 1, "latency_ms": 5},
+        {"hop": 2, "latency_ms": 10},
+    ]
+    return {"src": src, "dst": dst, "hops": hops}

--- a/app/planner.py
+++ b/app/planner.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+from typing import Dict
+
+
+def recommend(site: str, intent_id: str, horizon: int) -> Dict[str, object]:
+    return {"site": site, "intentId": intent_id, "recommendation": "scale_out", "horizonDays": horizon}

--- a/app/policy_impact.py
+++ b/app/policy_impact.py
@@ -1,0 +1,4 @@
+from typing import Dict, List
+
+def timeline(policy_id: str, before: str, after: str) -> Dict[str, List[str]]:
+    return {"policy": policy_id, "before": before, "after": after, "changes": []}

--- a/app/quantumshield.py
+++ b/app/quantumshield.py
@@ -1,0 +1,10 @@
+"""Minimal DV8 QuantumShield placeholder utilities."""
+from typing import Dict
+
+def risk_score(status: str, latency: float = 0.0) -> int:
+    score = 0
+    if status == "down":
+        score += 70
+    if latency > 50:
+        score += 20
+    return min(score, 100)

--- a/app/sandbox.py
+++ b/app/sandbox.py
@@ -1,0 +1,83 @@
+from typing import Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from .db import Device, Warning, AuditLog
+
+
+def register(db: Session, name: str, device_type: str, ports: int, status: str = "up", warnings: Optional[Dict[str, bool]] = None) -> Dict[str, object]:
+    device = db.query(Device).filter_by(name=name).first()
+    if not device:
+        device = Device(name=name, device_type=device_type, ports=ports, status=status)
+        db.add(device)
+        db.flush()
+    else:
+        device.device_type = device_type
+        device.ports = ports
+        device.status = status
+        for w in list(device.warnings):
+            db.delete(w)
+    if warnings:
+        for w_name, active in warnings.items():
+            db.add(Warning(device_id=device.id, name=w_name, active=active))
+    db.add(AuditLog(action="sandbox_register", entity="device", entity_id=device.id))
+    db.commit()
+    return serialize_device(device)
+
+
+def get(db: Session, name: str) -> Optional[Dict[str, object]]:
+    device = db.query(Device).filter_by(name=name).first()
+    if not device:
+        return None
+    return serialize_device(device)
+
+
+def update(db: Session, name: str, status: Optional[str] = None, warnings: Optional[Dict[str, bool]] = None) -> Optional[Dict[str, object]]:
+    device = db.query(Device).filter_by(name=name).first()
+    if not device:
+        return None
+    if status is not None:
+        device.status = status
+    if warnings:
+        for w_name, active in warnings.items():
+            w = db.query(Warning).filter_by(device_id=device.id, name=w_name).first()
+            if w:
+                w.active = active
+            else:
+                db.add(Warning(device_id=device.id, name=w_name, active=active))
+    db.add(AuditLog(action="sandbox_update", entity="device", entity_id=device.id))
+    db.commit()
+    return serialize_device(device)
+
+
+def list_devices(db: Session) -> List[Dict[str, object]]:
+    devices = db.query(Device).all()
+    return [serialize_device(d) for d in devices]
+
+
+def summary(db: Session) -> Dict[str, object]:
+    devices = db.query(Device).all()
+    total_ports = sum(d.ports for d in devices)
+    status_counts: Dict[str, int] = {}
+    warning_counts: Dict[str, int] = {}
+    for d in devices:
+        status_counts[d.status] = status_counts.get(d.status, 0) + 1
+        for w in d.warnings:
+            if w.active:
+                warning_counts[w.name] = warning_counts.get(w.name, 0) + 1
+    return {
+        "total_devices": len(devices),
+        "total_ports": total_ports,
+        "status_counts": status_counts,
+        "warning_counts": warning_counts,
+    }
+
+
+def serialize_device(device: Device) -> Dict[str, object]:
+    return {
+        "name": device.name,
+        "device_type": device.device_type,
+        "ports": device.ports,
+        "status": device.status,
+        "warnings": {w.name: w.active for w in device.warnings},
+    }

--- a/app/self_heal.py
+++ b/app/self_heal.py
@@ -1,0 +1,15 @@
+from typing import List
+from .db import SessionLocal, Device, AuditLog
+from .quantumshield import risk_score
+
+def heal_devices() -> List[str]:
+    healed: List[str] = []
+    with SessionLocal() as db:
+        devices = db.query(Device).all()
+        for d in devices:
+            if d.status == "down" and risk_score(d.status) < 80:
+                d.status = "up"
+                healed.append(d.name)
+                db.add(AuditLog(action="self_heal", entity="device", entity_id=d.id))
+        db.commit()
+    return healed

--- a/app/synthetics.py
+++ b/app/synthetics.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import Dict, List
+
+_probes: List[Dict[str, object]] = []
+
+
+def create_probe(intent_id: str, endpoints: List[str], proto: str, interval: int) -> Dict[str, object]:
+    probe = {"id": len(_probes) + 1, "intentId": intent_id, "endpoints": endpoints, "proto": proto, "interval": interval}
+    _probes.append(probe)
+    return probe
+
+
+def get_results(intent_id: str) -> List[Dict[str, object]]:
+    # stubbed results
+    return [{"intentId": intent_id, "endpoint": ep, "latency_ms": 10.0} for ep in ["synthetic"]]

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+    <title>DV8 Network Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<h1>Network Metrics</h1>
+<p>Average latency: {{ data.avg_latency }} ms</p>
+<canvas id="latencyChart" width="400" height="200"></canvas>
+<script>
+const ctx = document.getElementById('latencyChart').getContext('2d');
+const labels = {{ data.devices | map(attribute='device') | list | safe }};
+const latencies = {{ data.devices | map(attribute='latency_ms') | list | safe }};
+new Chart(ctx, {
+    type: 'bar',
+    data: {
+        labels: labels,
+        datasets: [{
+            label: 'Latency (ms)',
+            data: latencies,
+            backgroundColor: 'rgba(54, 162, 235, 0.5)',
+        }]
+    }
+});
+</script>
+</body>
+</html>

--- a/app/vulnwatch.py
+++ b/app/vulnwatch.py
@@ -1,0 +1,11 @@
+from typing import Dict
+from sqlalchemy.orm import Session
+from .db import AuditLog
+
+def sync(db: Session) -> Dict[str, str]:
+    db.add(AuditLog(action="vuln_sync", entity="cve"))
+    db.commit()
+    return {"status": "synced"}
+
+def findings(device: str) -> Dict[str, list]:
+    return {"device": device, "vulnerabilities": []}

--- a/app/zero_error.py
+++ b/app/zero_error.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from .db import SessionLocal, AuditLog
+
+def init_zero_error(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def zero_error_middleware(request: Request, call_next):
+        try:
+            return await call_next(request)
+        except Exception as exc:
+            with SessionLocal() as db:
+                db.add(AuditLog(action="error", entity="system", details=str(exc)))
+                db.commit()
+            return JSONResponse(status_code=500, content={"detail": "internal error"})

--- a/app/zero_touch.py
+++ b/app/zero_touch.py
@@ -1,0 +1,46 @@
+from typing import List, Optional, Dict
+
+from sqlalchemy.orm import Session
+
+from .db import Device, ZeroTouchConfig, AuditLog
+
+
+def enroll(db: Session, name: str, template: str) -> Dict[str, object]:
+    device = db.query(Device).filter_by(name=name).first()
+    if not device:
+        device = Device(name=name)
+        db.add(device)
+        db.flush()
+    zt = db.query(ZeroTouchConfig).filter_by(device_id=device.id).first()
+    if zt:
+        zt.template = template
+    else:
+        zt = ZeroTouchConfig(device_id=device.id, template=template)
+        db.add(zt)
+    db.add(AuditLog(action="zero_touch_enroll", entity="device", entity_id=device.id, details=template))
+    db.commit()
+    return {"name": name, "template": template, "applied": zt.applied}
+
+
+def get(db: Session, name: str) -> Optional[Dict[str, object]]:
+    device = db.query(Device).filter_by(name=name).first()
+    if not device or not device.zero_touch:
+        return None
+    zt = device.zero_touch
+    return {"name": name, "template": zt.template, "applied": zt.applied}
+
+
+def list_devices(db: Session) -> List[Dict[str, object]]:
+    zts = db.query(ZeroTouchConfig).all()
+    return [{"name": z.device.name, "template": z.template, "applied": z.applied} for z in zts]
+
+
+def mark_applied(db: Session, name: str) -> Optional[Dict[str, object]]:
+    device = db.query(Device).filter_by(name=name).first()
+    if not device or not device.zero_touch:
+        return None
+    zt = device.zero_touch
+    zt.applied = True
+    db.add(AuditLog(action="zero_touch_applied", entity="device", entity_id=device.id))
+    db.commit()
+    return {"name": name, "template": zt.template, "applied": zt.applied}

--- a/charts/ssfm/values.yaml
+++ b/charts/ssfm/values.yaml
@@ -1,0 +1,35 @@
+image:
+  repo: registry.dv8/ssfm
+  tag: v0.1.0
+ingress:
+  enabled: true
+  hosts: [ssfm.dv8]
+  tls: [{ secretName: ssfm-tls, hosts: [ssfm.dv8] }]
+features:
+  discovery: true
+  sandbox: true
+  firmwareLCM: true
+secrets:
+  vaultAddr: https://vault.dv8
+  mount: kv/ssfm
+gatekeeperPolicies:
+  enforceSignedImages: true
+  dropCapabilities: ["ALL"]
+
+quantumshield:
+  enabled: true
+  hoac:
+    defaultProfile: ECC
+    pqcThreshold: 70
+  set:
+    keyRotationHours: 24
+  lso:
+    exportDefault: false
+ccp:
+  replicas: 3
+  decisionsTopic: "security.ccp.decisions"
+aic:
+  capsules: ["SessionOracle","EntropyGuard","KeySurgeon","VectorMind"]
+vault:
+  mount: kv/ssfm
+  hsmEnabled: true

--- a/dotnet/DV8.Console.sln
+++ b/dotnet/DV8.Console.sln
@@ -1,0 +1,36 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{6657BF00-F5F0-4078-B01A-057C72DE5FFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DV8.Console", "src\DV8.Console\DV8.Console.csproj", "{6DB6AB8B-2DC0-4D17-A077-DE92000EC2FD}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{1C51DF24-82C1-41A9-8675-49CDFEDE7837}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DV8.Console.Tests", "tests\DV8.Console.Tests\DV8.Console.Tests.csproj", "{B062C211-630A-4E49-91BE-2B92E11A35E5}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{6DB6AB8B-2DC0-4D17-A077-DE92000EC2FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6DB6AB8B-2DC0-4D17-A077-DE92000EC2FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6DB6AB8B-2DC0-4D17-A077-DE92000EC2FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6DB6AB8B-2DC0-4D17-A077-DE92000EC2FD}.Release|Any CPU.Build.0 = Release|Any CPU
+{B062C211-630A-4E49-91BE-2B92E11A35E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{B062C211-630A-4E49-91BE-2B92E11A35E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{B062C211-630A-4E49-91BE-2B92E11A35E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{B062C211-630A-4E49-91BE-2B92E11A35E5}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(NestedProjects) = preSolution
+{6DB6AB8B-2DC0-4D17-A077-DE92000EC2FD} = {6657BF00-F5F0-4078-B01A-057C72DE5FFE}
+{B062C211-630A-4E49-91BE-2B92E11A35E5} = {1C51DF24-82C1-41A9-8675-49CDFEDE7837}
+EndGlobalSection
+EndGlobal

--- a/dotnet/src/DV8.Console/Controllers/AnalyticsController.cs
+++ b/dotnet/src/DV8.Console/Controllers/AnalyticsController.cs
@@ -1,0 +1,29 @@
+using DV8.Console.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("analytics")]
+    public class AnalyticsController : ControllerBase
+    {
+        private readonly AnalyticsService _service;
+        public AnalyticsController(AnalyticsService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("latency")]
+        public ActionResult<double> GetAverageLatency()
+        {
+            return _service.AverageLatency();
+        }
+
+        [HttpGet("status")]
+        public ActionResult<Dictionary<string, int>> GetStatusDistribution()
+        {
+            return _service.StatusDistribution();
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/AutoHealerController.cs
+++ b/dotnet/src/DV8.Console/Controllers/AutoHealerController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("heal")]
+    public class AutoHealerController : ControllerBase
+    {
+        private readonly AutoHealerService _service;
+        public AutoHealerController(AutoHealerService svc) { _service = svc; }
+
+        [HttpPost("playbooks")]
+        public ActionResult<Dictionary<string, object>> CreatePlaybook([FromBody] Dictionary<string, object> body)
+            => _service.CreatePlaybook(body["name"].ToString()!);
+
+        [HttpGet("incidents")]
+        public IEnumerable<Dictionary<string, object>> ListIncidents()
+            => _service.ListIncidents();
+
+        [HttpPost("incidents/{id}/execute")]
+        public ActionResult<Dictionary<string, object>> Execute(int id)
+        {
+            var result = _service.ExecuteIncident(id);
+            if (result == null) return NotFound();
+            return result;
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/ComplianceController.cs
+++ b/dotnet/src/DV8.Console/Controllers/ComplianceController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("compliance")]
+    public class ComplianceController : ControllerBase
+    {
+        private readonly ComplianceService _service;
+        public ComplianceController(ComplianceService service)
+        {
+            _service = service;
+        }
+
+        [HttpPost("scan")]
+        public ActionResult<Dictionary<string,string>> Scan([FromBody] Dictionary<string,string> req)
+        {
+            return _service.StartScan(req["profile"]);
+        }
+
+        [HttpGet("results")]
+        public ActionResult<Dictionary<string,string>> Results([FromQuery] string profile, [FromQuery] string device)
+        {
+            return _service.Results(profile, device);
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/DiscoveryController.cs
+++ b/dotnet/src/DV8.Console/Controllers/DiscoveryController.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("discovery")]
+    public class DiscoveryController : ControllerBase
+    {
+        private readonly DiscoveryService _service;
+        public DiscoveryController(DiscoveryService service)
+        {
+            _service = service;
+        }
+
+        public record StartRequest(string Tenant, IEnumerable<string> Scopes, IEnumerable<string> Cidrs, bool PassiveOnly);
+
+        [HttpPost("jobs")]
+        public ActionResult<DiscoveryJob> StartJob(StartRequest req)
+        {
+            var job = _service.Start(req.Tenant, req.Scopes, req.Cidrs, req.PassiveOnly);
+            return Accepted(job);
+        }
+
+        [HttpGet("jobs/{id}")]
+        public ActionResult<DiscoveryJob> GetJob(string id)
+        {
+            var job = _service.Get(id);
+            if (job == null)
+            {
+                return NotFound();
+            }
+            return job;
+        }
+
+        [HttpGet("candidates")]
+        public IEnumerable<Candidate> Candidates([FromQuery] string tenant)
+        {
+            return _service.Candidates(tenant);
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/FirmwareController.cs
+++ b/dotnet/src/DV8.Console/Controllers/FirmwareController.cs
@@ -1,0 +1,35 @@
+using DV8.Console.Models;
+using DV8.Console.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("firmware")]
+    public class FirmwareController : ControllerBase
+    {
+        private readonly FirmwareManager _manager;
+        public FirmwareController(FirmwareManager manager)
+        {
+            _manager = manager;
+        }
+
+        [HttpPost("install")]
+        public IActionResult Install(FirmwareInstallRequest request)
+        {
+            _manager.Install(request.DeviceId, request.Version);
+            return Ok(new { deviceId = request.DeviceId, version = request.Version });
+        }
+
+        [HttpGet("version/{deviceId}")]
+        public IActionResult GetVersion(string deviceId)
+        {
+            var version = _manager.GetVersion(deviceId);
+            if (version == null)
+            {
+                return NotFound();
+            }
+            return Ok(new { deviceId, version });
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/GuardRailController.cs
+++ b/dotnet/src/DV8.Console/Controllers/GuardRailController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("guardrail")]
+    public class GuardRailController : ControllerBase
+    {
+        private readonly GuardRailService _service;
+        public GuardRailController(GuardRailService svc) { _service = svc; }
+
+        [HttpPost("lint")]
+        public object Lint([FromBody] Dictionary<string, string> body)
+            => new { valid = _service.Lint(body["intentYaml"]) };
+
+        [HttpPost("approve")]
+        public object Approve([FromBody] Dictionary<string, string> body)
+            => _service.Approve(body["changeId"]);
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/PathTracerController.cs
+++ b/dotnet/src/DV8.Console/Controllers/PathTracerController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("sdwan")]
+    public class PathTracerController : ControllerBase
+    {
+        private readonly PathTracerService _service;
+        public PathTracerController(PathTracerService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet("pathtracer")]
+        public ActionResult<Dictionary<string,object>> Trace([FromQuery] string src, [FromQuery] string dst)
+        {
+            return _service.Trace(src, dst);
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/PlannerController.cs
+++ b/dotnet/src/DV8.Console/Controllers/PlannerController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("planner")]
+    public class PlannerController : ControllerBase
+    {
+        private readonly PlannerService _svc;
+        public PlannerController(PlannerService svc) { _svc = svc; }
+
+        [HttpPost("recommend")]
+        public object Recommend([FromBody] Dictionary<string, object> body)
+            => _svc.Recommend(body["site"].ToString()!, body["intentId"].ToString()!, (int)body["horizonDays"]);
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/SandboxController.cs
+++ b/dotnet/src/DV8.Console/Controllers/SandboxController.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Models;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("sandbox")]
+    public class SandboxController : ControllerBase
+    {
+        private readonly SandboxManager _manager;
+        public SandboxController(SandboxManager manager)
+        {
+            _manager = manager;
+        }
+
+        [HttpPost("device")]
+        public ActionResult<SandboxDevice> Register(SandboxDevice device)
+        {
+            return _manager.Register(device);
+        }
+
+        [HttpGet("devices")]
+        public IEnumerable<SandboxDevice> List() => _manager.List();
+
+        [HttpGet("device/{name}")]
+        public ActionResult<SandboxDevice> Get(string name)
+        {
+            var device = _manager.Get(name);
+            if (device == null)
+            {
+                return NotFound();
+            }
+            return device;
+        }
+
+        [HttpPut("device/{name}")]
+        public ActionResult<SandboxDevice> Update(string name, StatusUpdate update)
+        {
+            var device = _manager.Update(name, update);
+            if (device == null)
+            {
+                return NotFound();
+            }
+            return device;
+        }
+
+        [HttpGet("summary")]
+        public object Summary() => _manager.Summary();
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/SelfHealController.cs
+++ b/dotnet/src/DV8.Console/Controllers/SelfHealController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("selfheal")]
+    public class SelfHealController : ControllerBase
+    {
+        private readonly SelfHealService _service;
+        public SelfHealController(SelfHealService service)
+        {
+            _service = service;
+        }
+
+        [HttpPost]
+        public ActionResult<IEnumerable<string>> Heal()
+        {
+            return Ok(_service.Heal());
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/SyntheticsController.cs
+++ b/dotnet/src/DV8.Console/Controllers/SyntheticsController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("synthetics")]
+    public class SyntheticsController : ControllerBase
+    {
+        private readonly SyntheticsService _svc;
+        public SyntheticsController(SyntheticsService svc) { _svc = svc; }
+
+        [HttpPost("probes")]
+        public object Register([FromBody] Dictionary<string, object> body)
+            => _svc.Register(body["intentId"].ToString()!, new[] { "a" }, body["proto"].ToString()!, (int)body["interval"]);
+
+        [HttpGet("results")]
+        public IEnumerable<Dictionary<string, object>> Results([FromQuery] string intentId)
+            => _svc.Results(intentId);
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/VulnWatchController.cs
+++ b/dotnet/src/DV8.Console/Controllers/VulnWatchController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+using System.Collections.Generic;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("vulnwatch")]
+    public class VulnWatchController : ControllerBase
+    {
+        private readonly VulnWatchService _service;
+        public VulnWatchController(VulnWatchService service)
+        {
+            _service = service;
+        }
+
+        [HttpPost("sync")]
+        public ActionResult<Dictionary<string,string>> Sync()
+        {
+            return _service.Sync();
+        }
+
+        [HttpGet("findings")]
+        public ActionResult<Dictionary<string,object>> Findings([FromQuery] string device)
+        {
+            return _service.Findings(device);
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Controllers/ZeroTouchController.cs
+++ b/dotnet/src/DV8.Console/Controllers/ZeroTouchController.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using DV8.Console.Services;
+
+namespace DV8.Console.Controllers
+{
+    [ApiController]
+    [Route("zero-touch")]
+    public class ZeroTouchController : ControllerBase
+    {
+        private readonly ZeroTouchService _service;
+        public ZeroTouchController(ZeroTouchService service)
+        {
+            _service = service;
+        }
+
+        [HttpPost("enroll")]
+        public IActionResult Enroll([FromBody] ZeroTouchRequest req)
+        {
+            var result = _service.Enroll(req.Name, req.Template);
+            return Ok(result);
+        }
+
+        [HttpPost("device/{name}/applied")]
+        public IActionResult MarkApplied(string name)
+        {
+            var result = _service.MarkApplied(name);
+            if (result == null) return NotFound();
+            return Ok(result);
+        }
+
+        [HttpGet("device/{name}")]
+        public IActionResult Get(string name)
+        {
+            var result = _service.Get(name);
+            if (result == null) return NotFound();
+            return Ok(result);
+        }
+
+        [HttpGet("devices")]
+        public IActionResult List()
+        {
+            return Ok(_service.List());
+        }
+    }
+
+    public record ZeroTouchRequest(string Name, string Template);
+}

--- a/dotnet/src/DV8.Console/DV8.Console.csproj
+++ b/dotnet/src/DV8.Console/DV8.Console.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/DV8.Console/DV8.Console.http
+++ b/dotnet/src/DV8.Console/DV8.Console.http
@@ -1,0 +1,6 @@
+@DV8.Console_HostAddress = http://localhost:5093
+
+GET {{DV8.Console_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/dotnet/src/DV8.Console/Middleware/ErrorHandlingMiddleware.cs
+++ b/dotnet/src/DV8.Console/Middleware/ErrorHandlingMiddleware.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace DV8.Console.Middleware
+{
+    public class ErrorHandlingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        public ErrorHandlingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch
+            {
+                if (!context.Response.HasStarted)
+                {
+                    context.Response.StatusCode = 500;
+                    await context.Response.WriteAsJsonAsync(new { error = "internal error" });
+                }
+            }
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Models/FirmwareInstallRequest.cs
+++ b/dotnet/src/DV8.Console/Models/FirmwareInstallRequest.cs
@@ -1,0 +1,4 @@
+namespace DV8.Console.Models
+{
+    public record FirmwareInstallRequest(string DeviceId, string Version);
+}

--- a/dotnet/src/DV8.Console/Models/SandboxDevice.cs
+++ b/dotnet/src/DV8.Console/Models/SandboxDevice.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Models
+{
+    public class SandboxDevice
+    {
+        public string Name { get; set; } = string.Empty;
+        public string DeviceType { get; set; } = string.Empty;
+        public int Ports { get; set; }
+        public string Status { get; set; } = "up";
+        public Dictionary<string, bool> Warnings { get; set; } = new();
+    }
+
+    public class StatusUpdate
+    {
+        public string? Status { get; set; }
+        public Dictionary<string, bool>? Warnings { get; set; }
+    }
+}

--- a/dotnet/src/DV8.Console/Program.cs
+++ b/dotnet/src/DV8.Console/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddSingleton<PlannerService>();
 builder.Services.AddSingleton<QuantumShieldService>();
 builder.Services.AddSingleton<SelfHealService>();
 builder.Services.AddSingleton<DiscoveryService>();
+builder.Services.AddSingleton<ZeroTouchService>();
 
 var app = builder.Build();
 
@@ -45,6 +46,7 @@ using (var scope = app.Services.CreateScope())
     scope.ServiceProvider.GetRequiredService<QuantumShieldService>();
     scope.ServiceProvider.GetRequiredService<SelfHealService>();
     scope.ServiceProvider.GetRequiredService<DiscoveryService>();
+    scope.ServiceProvider.GetRequiredService<ZeroTouchService>();
 }
 
 if (app.Environment.IsDevelopment())

--- a/dotnet/src/DV8.Console/Program.cs
+++ b/dotnet/src/DV8.Console/Program.cs
@@ -1,0 +1,60 @@
+using DV8.Console.Services;
+using Microsoft.Extensions.DependencyInjection;
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<FirmwareManager>();
+builder.Services.AddSingleton<AnalyticsService>();
+builder.Services.AddSingleton<SandboxManager>();
+builder.Services.AddSingleton<ComplianceService>();
+builder.Services.AddSingleton<VulnWatchService>();
+builder.Services.AddSingleton<PathTracerService>();
+builder.Services.AddSingleton<AutoHealerService>();
+builder.Services.AddSingleton<GuardRailService>();
+builder.Services.AddSingleton<SyntheticsService>();
+builder.Services.AddSingleton<PlannerService>();
+builder.Services.AddSingleton<QuantumShieldService>();
+builder.Services.AddSingleton<SelfHealService>();
+builder.Services.AddSingleton<DiscoveryService>();
+
+var app = builder.Build();
+
+app.UseMiddleware<DV8.Console.Middleware.ErrorHandlingMiddleware>();
+app.Use(async (ctx, next) =>
+{
+    await next();
+    if (!ctx.Response.Headers.ContainsKey("X-DV8-Decision"))
+        ctx.Response.Headers.Add("X-DV8-Decision", "ALLOW");
+});
+
+using (var scope = app.Services.CreateScope())
+{
+    scope.ServiceProvider.GetRequiredService<FirmwareManager>();
+    scope.ServiceProvider.GetRequiredService<AnalyticsService>();
+    scope.ServiceProvider.GetRequiredService<SandboxManager>();
+    scope.ServiceProvider.GetRequiredService<ComplianceService>();
+    scope.ServiceProvider.GetRequiredService<VulnWatchService>();
+    scope.ServiceProvider.GetRequiredService<PathTracerService>();
+    scope.ServiceProvider.GetRequiredService<AutoHealerService>();
+    scope.ServiceProvider.GetRequiredService<GuardRailService>();
+    scope.ServiceProvider.GetRequiredService<SyntheticsService>();
+    scope.ServiceProvider.GetRequiredService<PlannerService>();
+    scope.ServiceProvider.GetRequiredService<QuantumShieldService>();
+    scope.ServiceProvider.GetRequiredService<SelfHealService>();
+    scope.ServiceProvider.GetRequiredService<DiscoveryService>();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+
+app.Run();
+
+public partial class Program { }

--- a/dotnet/src/DV8.Console/Properties/launchSettings.json
+++ b/dotnet/src/DV8.Console/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:2482",
+      "sslPort": 44391
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5093",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7019;http://localhost:5093",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/dotnet/src/DV8.Console/Services/AnalyticsService.cs
+++ b/dotnet/src/DV8.Console/Services/AnalyticsService.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DV8.Console.Services
+{
+    public class AnalyticsService
+    {
+        private readonly List<int> _latencies = new() { 10, 20, 30 };
+        private readonly List<string> _statuses = new() { "online", "offline", "offline", "maintenance" };
+
+        public double AverageLatency()
+        {
+            return _latencies.Any() ? _latencies.Average() : 0;
+        }
+
+        public Dictionary<string, int> StatusDistribution()
+        {
+            return _statuses
+                .GroupBy(s => s)
+                .ToDictionary(g => g.Key, g => g.Count());
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/AutoHealerService.cs
+++ b/dotnet/src/DV8.Console/Services/AutoHealerService.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class AutoHealerService
+    {
+        private readonly Dictionary<int, Dictionary<string, object>> _playbooks = new();
+        private readonly Dictionary<int, Dictionary<string, object>> _incidents = new();
+
+        public Dictionary<string, object> CreatePlaybook(string name)
+        {
+            var id = _playbooks.Count + 1;
+            var pb = new Dictionary<string, object>{{"id", id}, {"name", name}};
+            _playbooks[id] = pb;
+            _incidents[id] = new Dictionary<string, object>{{"id", id}, {"playbookId", id}, {"state", "open"}};
+            return pb;
+        }
+
+        public IEnumerable<Dictionary<string, object>> ListIncidents()
+            => _incidents.Values;
+
+        public Dictionary<string, object>? ExecuteIncident(int id)
+        {
+            if (_incidents.TryGetValue(id, out var inc) && (string)inc["state"] == "open")
+            {
+                inc["state"] = "closed";
+                return inc;
+            }
+            return null;
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/ComplianceService.cs
+++ b/dotnet/src/DV8.Console/Services/ComplianceService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class ComplianceService
+    {
+        public Dictionary<string,string> StartScan(string profile)
+        {
+            return new Dictionary<string,string>{{"job", profile + "-scan"}};
+        }
+
+        public Dictionary<string,string> Results(string profile, string device)
+        {
+            return new Dictionary<string,string>{{"device", device}, {"profile", profile}, {"status", "pass"}};
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/DiscoveryService.cs
+++ b/dotnet/src/DV8.Console/Services/DiscoveryService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class DiscoveryService
+    {
+        private readonly Dictionary<string, DiscoveryJob> _jobs = new();
+        private readonly List<Candidate> _candidates = new();
+
+        public DiscoveryJob Start(string tenant, IEnumerable<string> scopes, IEnumerable<string> cidrs, bool passiveOnly)
+        {
+            var job = new DiscoveryJob
+            {
+                Id = Guid.NewGuid().ToString(),
+                Status = "running",
+                StartedAt = DateTime.UtcNow,
+                Tenant = tenant,
+                Scopes = new List<string>(scopes),
+                Cidrs = new List<string>(cidrs),
+                PassiveOnly = passiveOnly
+            };
+            _jobs[job.Id] = job;
+            return job;
+        }
+
+        public DiscoveryJob? Get(string id)
+        {
+            return _jobs.TryGetValue(id, out var job) ? job : null;
+        }
+
+        public IEnumerable<Candidate> Candidates(string tenant)
+        {
+            return _candidates;
+        }
+    }
+
+    public class DiscoveryJob
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public DateTime StartedAt { get; set; }
+        public string Tenant { get; set; } = string.Empty;
+        public List<string> Scopes { get; set; } = new();
+        public List<string> Cidrs { get; set; } = new();
+        public bool PassiveOnly { get; set; }
+    }
+
+    public class Candidate
+    {
+        public string Fp { get; set; } = string.Empty;
+        public List<string> Addrs { get; set; } = new();
+        public List<string> Signals { get; set; } = new();
+        public float Confidence { get; set; }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/FirmwareManager.cs
+++ b/dotnet/src/DV8.Console/Services/FirmwareManager.cs
@@ -1,0 +1,19 @@
+using System.Collections.Concurrent;
+
+namespace DV8.Console.Services
+{
+    public class FirmwareManager
+    {
+        private readonly ConcurrentDictionary<string, string> _versions = new();
+
+        public void Install(string deviceId, string version)
+        {
+            _versions[deviceId] = version;
+        }
+
+        public string? GetVersion(string deviceId)
+        {
+            return _versions.TryGetValue(deviceId, out var v) ? v : null;
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/GuardRailService.cs
+++ b/dotnet/src/DV8.Console/Services/GuardRailService.cs
@@ -1,0 +1,8 @@
+namespace DV8.Console.Services
+{
+    public class GuardRailService
+    {
+        public bool Lint(string intentYaml) => intentYaml.Contains("policy");
+        public object Approve(string changeId) => new { changeId, status = "approved" };
+    }
+}

--- a/dotnet/src/DV8.Console/Services/PathTracerService.cs
+++ b/dotnet/src/DV8.Console/Services/PathTracerService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class PathTracerService
+    {
+        public Dictionary<string,object> Trace(string src, string dst)
+        {
+            var hops = new List<Dictionary<string,int>>
+            {
+                new Dictionary<string,int>{{"hop",1},{"latency_ms",5}},
+                new Dictionary<string,int>{{"hop",2},{"latency_ms",10}}
+            };
+            return new Dictionary<string,object>{{"src",src},{"dst",dst},{"hops",hops}};
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/PlannerService.cs
+++ b/dotnet/src/DV8.Console/Services/PlannerService.cs
@@ -1,0 +1,8 @@
+namespace DV8.Console.Services
+{
+    public class PlannerService
+    {
+        public object Recommend(string site, string intentId, int horizonDays)
+            => new { site, intentId, recommendation = "scale_out", horizonDays };
+    }
+}

--- a/dotnet/src/DV8.Console/Services/QuantumShieldService.cs
+++ b/dotnet/src/DV8.Console/Services/QuantumShieldService.cs
@@ -1,0 +1,13 @@
+namespace DV8.Console.Services
+{
+    public class QuantumShieldService
+    {
+        public int RiskScore(string status, int latency = 0)
+        {
+            var score = 0;
+            if (status == "down") score += 70;
+            if (latency > 50) score += 20;
+            return score > 100 ? 100 : score;
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/SandboxManager.cs
+++ b/dotnet/src/DV8.Console/Services/SandboxManager.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using DV8.Console.Models;
+
+namespace DV8.Console.Services
+{
+    public class SandboxManager
+    {
+        private readonly Dictionary<string, SandboxDevice> _devices = new();
+
+        public SandboxDevice Register(SandboxDevice device)
+        {
+            _devices[device.Name] = device;
+            return device;
+        }
+
+        public IEnumerable<SandboxDevice> List() => _devices.Values;
+
+        public SandboxDevice? Get(string name)
+        {
+            _devices.TryGetValue(name, out var device);
+            return device;
+        }
+
+        public SandboxDevice? Update(string name, StatusUpdate update)
+        {
+            if (!_devices.TryGetValue(name, out var device))
+            {
+                return null;
+            }
+            if (update.Status != null)
+            {
+                device.Status = update.Status;
+            }
+            if (update.Warnings != null)
+            {
+                foreach (var kv in update.Warnings)
+                {
+                    device.Warnings[kv.Key] = kv.Value;
+                }
+            }
+            return device;
+        }
+
+        public object Summary()
+        {
+            var totalPorts = _devices.Values.Sum(d => d.Ports);
+            var statusCounts = _devices.Values
+                .GroupBy(d => d.Status)
+                .ToDictionary(g => g.Key, g => g.Count());
+            var warningCounts = new Dictionary<string, int>();
+            foreach (var d in _devices.Values)
+            {
+                foreach (var w in d.Warnings.Where(kv => kv.Value))
+                {
+                    warningCounts[w.Key] = warningCounts.GetValueOrDefault(w.Key) + 1;
+                }
+            }
+            return new
+            {
+                totalDevices = _devices.Count,
+                totalPorts,
+                statusCounts,
+                warningCounts
+            };
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/SelfHealService.cs
+++ b/dotnet/src/DV8.Console/Services/SelfHealService.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using DV8.Console.Models;
+
+namespace DV8.Console.Services
+{
+    public class SelfHealService
+    {
+        private readonly SandboxManager _sandbox;
+        private readonly QuantumShieldService _qs;
+        public SelfHealService(SandboxManager sandbox, QuantumShieldService qs)
+        {
+            _sandbox = sandbox;
+            _qs = qs;
+        }
+
+        public IEnumerable<string> Heal()
+        {
+            var healed = new List<string>();
+            foreach (var d in _sandbox.List())
+            {
+                if (d.Status == "down" && _qs.RiskScore(d.Status) < 80)
+                {
+                    d.Status = "up";
+                    healed.Add(d.Name);
+                }
+            }
+            return healed;
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/SyntheticsService.cs
+++ b/dotnet/src/DV8.Console/Services/SyntheticsService.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class SyntheticsService
+    {
+        private readonly List<Dictionary<string, object>> _probes = new();
+
+        public Dictionary<string, object> Register(string intentId, IEnumerable<string> endpoints, string proto, int interval)
+        {
+            var probe = new Dictionary<string, object>{{"id", _probes.Count + 1}, {"intentId", intentId}, {"proto", proto}, {"interval", interval}};
+            _probes.Add(probe);
+            return probe;
+        }
+
+        public IEnumerable<Dictionary<string, object>> Results(string intentId)
+        {
+            return new List<Dictionary<string, object>>
+            {
+                new() { {"intentId", intentId}, {"endpoint", "synthetic"}, {"latencyMs", 10} }
+            };
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/VulnWatchService.cs
+++ b/dotnet/src/DV8.Console/Services/VulnWatchService.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class VulnWatchService
+    {
+        public Dictionary<string,string> Sync()
+        {
+            return new Dictionary<string,string>{{"status","synced"}};
+        }
+
+        public Dictionary<string,object> Findings(string device)
+        {
+            return new Dictionary<string,object>{{"device", device}, {"vulnerabilities", new List<string>()}};
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/Services/ZeroTouchService.cs
+++ b/dotnet/src/DV8.Console/Services/ZeroTouchService.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+
+namespace DV8.Console.Services
+{
+    public class ZeroTouchService
+    {
+        private readonly Dictionary<string, (string Template, bool Applied)> _devices = new();
+
+        public object Enroll(string name, string template)
+        {
+            if (_devices.ContainsKey(name))
+            {
+                var existing = _devices[name];
+                _devices[name] = (template, existing.Applied);
+            }
+            else
+            {
+                _devices[name] = (template, false);
+            }
+            return new { name, template, applied = _devices[name].Applied };
+        }
+
+        public object? Get(string name)
+        {
+            if (_devices.TryGetValue(name, out var info))
+                return new { name, template = info.Template, applied = info.Applied };
+            return null;
+        }
+
+        public IEnumerable<object> List()
+        {
+            foreach (var kv in _devices)
+                yield return new { name = kv.Key, template = kv.Value.Template, applied = kv.Value.Applied };
+        }
+
+        public object? MarkApplied(string name)
+        {
+            if (_devices.TryGetValue(name, out var info))
+            {
+                _devices[name] = (info.Template, true);
+                return new { name, template = info.Template, applied = true };
+            }
+            return null;
+        }
+    }
+}

--- a/dotnet/src/DV8.Console/appsettings.Development.json
+++ b/dotnet/src/DV8.Console/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/dotnet/src/DV8.Console/appsettings.json
+++ b/dotnet/src/DV8.Console/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/dotnet/tests/DV8.Console.Tests/AutoHealerControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/AutoHealerControllerTests.cs
@@ -1,0 +1,27 @@
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DV8.Console.Tests
+{
+    public class AutoHealerControllerTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly HttpClient _client;
+        public AutoHealerControllerTests(WebApplicationFactory<Program> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task PlaybookLifecycle()
+        {
+            var pb = await _client.PostAsJsonAsync("/heal/playbooks", new { name = "pb" });
+            pb.EnsureSuccessStatusCode();
+            var incs = await _client.GetFromJsonAsync<System.Collections.Generic.List<System.Collections.Generic.Dictionary<string, object>>>("/heal/incidents");
+            Assert.NotNull(incs);
+            var exec = await _client.PostAsync("/heal/incidents/1/execute", null);
+            Assert.True(exec.IsSuccessStatusCode);
+        }
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/ComplianceAndPathTracerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/ComplianceAndPathTracerTests.cs
@@ -1,0 +1,32 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DV8.Console.Tests;
+
+public class ComplianceAndPathTracerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    public ComplianceAndPathTracerTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ComplianceScanAndResults()
+    {
+        var scan = await _client.PostAsJsonAsync("/compliance/scan", new Dictionary<string,string>{{"profile","DISA"}});
+        scan.EnsureSuccessStatusCode();
+        var results = await _client.GetAsync("/compliance/results?profile=DISA&device=r1");
+        results.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task PathTracerEndpoint()
+    {
+        var trace = await _client.GetAsync("/sdwan/pathtracer?src=a&dst=b");
+        trace.EnsureSuccessStatusCode();
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/DV8.Console.Tests.csproj
+++ b/dotnet/tests/DV8.Console.Tests/DV8.Console.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DV8.Console\DV8.Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/tests/DV8.Console.Tests/DiscoveryControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/DiscoveryControllerTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using DV8.Console.Services;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace DV8.Console.Tests;
+
+public class DiscoveryControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public DiscoveryControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task StartJobAndGetStatus()
+    {
+        var request = new { Tenant = "t1", Scopes = new[] { "site:A" }, Cidrs = new[] { "10.0.0.0/24" }, PassiveOnly = false };
+        var resp = await _client.PostAsJsonAsync("/discovery/jobs", request);
+        Assert.Equal(System.Net.HttpStatusCode.Accepted, resp.StatusCode);
+        var job = await resp.Content.ReadFromJsonAsync<DiscoveryJob>();
+        Assert.NotNull(job);
+        var status = await _client.GetAsync($"/discovery/jobs/{job!.Id}");
+        status.EnsureSuccessStatusCode();
+        var list = await _client.GetFromJsonAsync<IEnumerable<Candidate>>("/discovery/candidates?tenant=t1");
+        Assert.NotNull(list);
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/FirmwareControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/FirmwareControllerTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace DV8.Console.Tests
+{
+    public class FirmwareControllerTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly HttpClient _client;
+
+        public FirmwareControllerTests(WebApplicationFactory<Program> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task InstallAndRetrieveVersion()
+        {
+            var installResponse = await _client.PostAsJsonAsync("/firmware/install", new { DeviceId = "r1", Version = "1.0" });
+            installResponse.EnsureSuccessStatusCode();
+
+            var versionResponse = await _client.GetAsync("/firmware/version/r1");
+            versionResponse.EnsureSuccessStatusCode();
+            var payload = await versionResponse.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+            Assert.NotNull(payload);
+            Assert.Equal("1.0", payload["version"]);
+        }
+
+        [Fact]
+        public async Task AnalyticsEndpointsReturnData()
+        {
+            var latency = await _client.GetFromJsonAsync<double>("/analytics/latency");
+            Assert.True(latency > 0);
+
+            var status = await _client.GetFromJsonAsync<Dictionary<string, int>>("/analytics/status");
+            Assert.True(status.ContainsKey("offline"));
+        }
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/GlobalUsings.cs
+++ b/dotnet/tests/DV8.Console.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/dotnet/tests/DV8.Console.Tests/GuardRailControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/GuardRailControllerTests.cs
@@ -1,0 +1,25 @@
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DV8.Console.Tests
+{
+    public class GuardRailControllerTests : IClassFixture<WebApplicationFactory<Program>>
+    {
+        private readonly HttpClient _client;
+        public GuardRailControllerTests(WebApplicationFactory<Program> factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        [Fact]
+        public async Task LintAndApprove()
+        {
+            var lint = await _client.PostAsJsonAsync("/guardrail/lint", new { intentYaml = "policy: allow" });
+            lint.EnsureSuccessStatusCode();
+            var approve = await _client.PostAsJsonAsync("/guardrail/approve", new { changeId = "1" });
+            approve.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/SandboxControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/SandboxControllerTests.cs
@@ -1,0 +1,35 @@
+using System.Net.Http.Json;
+using System.Collections.Generic;
+using DV8.Console.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace DV8.Console.Tests;
+
+public class SandboxControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public SandboxControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task DeviceLifecycle()
+    {
+        var device = new SandboxDevice { Name = "sim-router", DeviceType = "router", Ports = 8 };
+        var resp = await _client.PostAsJsonAsync("/sandbox/device", device);
+        resp.EnsureSuccessStatusCode();
+
+        var update = new StatusUpdate { Status = "down", Warnings = new Dictionary<string, bool> { ["temperature"] = true } };
+        var resp2 = await _client.PutAsJsonAsync("/sandbox/device/sim-router", update);
+        resp2.EnsureSuccessStatusCode();
+        var updated = await resp2.Content.ReadFromJsonAsync<SandboxDevice>();
+        Assert.Equal("down", updated!.Status);
+        Assert.True(updated.Warnings["temperature"]);
+
+        var summary = await _client.GetFromJsonAsync<Dictionary<string, System.Text.Json.JsonElement>>("/sandbox/summary");
+        Assert.NotNull(summary);
+        Assert.True(summary!["totalDevices"].GetInt32() >= 1);
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/SelfHealControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/SelfHealControllerTests.cs
@@ -1,0 +1,28 @@
+using System.Net.Http.Json;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Testing;
+using DV8.Console.Models;
+using Xunit;
+
+namespace DV8.Console.Tests;
+
+public class SelfHealControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    public SelfHealControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task SelfHealRecoversDevice()
+    {
+        var device = new SandboxDevice { Name = "heal-router", DeviceType = "router", Ports = 4, Status = "down" };
+        var resp = await _client.PostAsJsonAsync("/sandbox/device", device);
+        resp.EnsureSuccessStatusCode();
+        var healResp = await _client.PostAsync("/selfheal", null);
+        healResp.EnsureSuccessStatusCode();
+        var healed = await healResp.Content.ReadFromJsonAsync<List<string>>();
+        Assert.Contains("heal-router", healed);
+    }
+}

--- a/dotnet/tests/DV8.Console.Tests/ZeroTouchControllerTests.cs
+++ b/dotnet/tests/DV8.Console.Tests/ZeroTouchControllerTests.cs
@@ -1,0 +1,38 @@
+using System.Net.Http.Json;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace DV8.Console.Tests;
+
+public class ZeroTouchControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public ZeroTouchControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task EnrollAndApply()
+    {
+        var resp = await _client.PostAsJsonAsync("/zero-touch/enroll", new { Name = "ztp-router", Template = "basic-router" });
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<ZeroTouchResponse>();
+        Assert.NotNull(body);
+        Assert.Equal("basic-router", body!.Template);
+        Assert.False(body.Applied);
+
+        var applied = await _client.PostAsync("/zero-touch/device/ztp-router/applied", null);
+        applied.EnsureSuccessStatusCode();
+        var appliedBody = await applied.Content.ReadFromJsonAsync<ZeroTouchResponse>();
+        Assert.NotNull(appliedBody);
+        Assert.True(appliedBody!.Applied);
+
+        var list = await _client.GetFromJsonAsync<List<ZeroTouchResponse>>("/zero-touch/devices");
+        Assert.True(list!.Count >= 1);
+    }
+}
+
+public record ZeroTouchResponse(string Name, string Template, bool Applied);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,114 @@
+openapi: 3.1.0
+info: { title: DV8 SS Flow Management API, version: "v1" }
+servers: [{ url: https://api.dv8/ssfm }]
+security: [{ DV8DBGID: [], mTLS: [] }]
+paths:
+  /v1/discovery/jobs:
+    post:
+      summary: Start discovery job
+      security: [{ DV8DBGID: [], mTLS: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tenant, scopes]
+              properties:
+                tenant: { type: string }
+                scopes:
+                  type: array
+                  items: { type: string, example: "site:ZA-JNB-DC" }
+                cidrs: { type: array, items: { type: string, example: "10.10.0.0/16" } }
+                passiveOnly: { type: boolean, default: false }
+      responses:
+        "202": { description: accepted, headers: { X-DV8-Decision: { $ref: "#/components/headers/X-DV8-Decision" }, Location: { schema: { type: string } } } }
+  /v1/discovery/jobs/{id}:
+    get:
+      summary: Get job status
+      security: [{ DV8DBGID: [], mTLS: [] }]
+      responses: { "200": { headers: { X-DV8-Decision: { $ref: "#/components/headers/X-DV8-Decision" } }, $ref: "#/components/schemas/DiscoveryJob" } }
+  /v1/discovery/candidates:
+    get:
+      summary: List candidates
+      security: [{ DV8DBGID: [], mTLS: [] }]
+      parameters: [{ name: tenant, in: query, required: true, schema: { type: string } }]
+      responses: { "200": { headers: { X-DV8-Decision: { $ref: "#/components/headers/X-DV8-Decision" } }, $ref: "#/components/schemas/CandidateList" } }
+  /v1/devices/{virtualId}:replace:
+    post:
+      summary: Replace virtual with physical device
+      security: [{ DV8DBGID: [], mTLS: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [serial, site]
+              properties:
+                serial: { type: string }
+                site: { type: string }
+                requireAttestation: { type: boolean, default: true }
+      responses:
+        "200": { description: swapped, headers: { X-DV8-Decision: { $ref: "#/components/headers/X-DV8-Decision" } }, content: { application/json: { schema: { $ref: "#/components/schemas/SwapResult" } } } }
+
+  /v1/ccp/adjudications:
+    post:
+      summary: Adjudicate a privileged action
+      security: [{ DV8DBGID: [], mTLS: [] }]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [actor, action, context]
+              properties:
+                actor: { type: string }
+                action: { type: string }
+                context:
+                  type: object
+                  properties:
+                    device: { type: string }
+                    site: { type: string }
+                    risk: { type: integer }
+      responses:
+        "200": { headers: { X-DV8-Decision: { $ref: "#/components/headers/X-DV8-Decision" } } }
+
+  /v1/crypto/hoac/negotiate:
+    post:
+      summary: Negotiate channel crypto (ECC/PQC)
+      security: [{ mTLS: [] }]
+      responses:
+        "200": { description: "Profile selected: ECC|PQC" }
+
+  /v1/audit/bundles:
+    post:
+      summary: Export ledger pack
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lso: { type: boolean, default: false }
+                scope: { type: object }
+      responses:
+        "201": { description: "Created", headers: { Location: { schema: { type: string } } } }
+components:
+  securitySchemes:
+    DV8DBGID: { type: apiKey, in: header, name: X-DV8-DBGID }
+    mTLS: { type: mutualTLS }
+  headers:
+    X-DV8-Decision:
+      schema: { type: string, enum: [ALLOW, ESCALATE, LOCK, DENY] }
+  schemas:
+    DiscoveryJob: { type: object, properties: { id: {type: string}, status: {type: string}, startedAt: {type: string, format: date-time} } }
+    CandidateList: { type: object, properties: { items: { type: array, items: { $ref: "#/components/schemas/Candidate" } } } }
+    Candidate:
+      type: object
+      properties:
+        fp: { type: string, description: fingerprint }
+        addrs: { type: array, items: { type: string } }
+        signals: { type: array, items: { type: string } }
+        confidence: { type: number }
+    SwapResult: { type: object, properties: { physicalId: {type: string}, ledger: {type: string} } }

--- a/proto/ccp.proto
+++ b/proto/ccp.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package dv8.ccp.v1;
+
+message Context { string device = 1; string site = 2; uint32 risk = 3; }
+message Req { string actor = 1; string action = 2; Context ctx = 3; }
+message Res {
+  enum Decision { ALLOW = 0; ESCALATE = 1; LOCK = 2; DENY = 3; }
+  Decision decision = 1;
+  string reason = 2;
+  map<string, string> obligations = 3;
+}
+service CCP { rpc Decide(Req) returns (Res); }

--- a/proto/discovery.proto
+++ b/proto/discovery.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package dv8.discovery.v1;
+
+message Scope { string tenant=1; repeated string cidrs=2; bool passive_only=3; }
+message Job { string id=1; string status=2; int64 started_at=3; }
+message Candidate {
+  string fp=1; repeated string addrs=2; repeated string signals=3; float confidence=4;
+  map<string,string> caps=5; // gNMI/NETCONF caps
+}
+service Discovery {
+  rpc Start(Scope) returns (Job);
+  rpc Status(Job) returns (Job);
+  rpc StreamCandidates(Job) returns (stream Candidate);
+}

--- a/proto/quantum.proto
+++ b/proto/quantum.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package dv8.crypto.v1;
+
+message HoacReq { string channel = 1; string policy = 2; uint32 risk = 3; }
+message HoacRes { string profile = 1; bytes transcript = 2; }
+service Quantum { rpc Negotiate(HoacReq) returns (HoacRes); }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+Jinja2==3.1.4
+pytest==8.2.2
+SQLAlchemy==2.0.30

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,54 @@
+create table device (
+  id uuid primary key,
+  tenant text not null,
+  kind text check (kind in ('router','switch','ap','virtual','gateway')),
+  vendor text, model text, sw_version text,
+  fingerprint text unique, trust_state jsonb,
+  site text, posture text check (posture in ('ECC','PQC')),
+  created_at timestamptz default now()
+);
+
+create table interface (
+  id uuid primary key, device_id uuid references device(id) on delete cascade,
+  name text, mac macaddr, ipv4 inet, ipv6 inet, speed_mbps int, up bool
+);
+
+create table neighbor (
+  a_if uuid references interface(id) on delete cascade,
+  z_if uuid references interface(id) on delete cascade,
+  proto text check (proto in ('lldp','cdp','bgp','passive')),
+  confidence real, primary key (a_if, z_if, proto)
+);
+
+create table discovery_job (
+  id uuid primary key, tenant text, passive_only bool, cidrs cidr[],
+  started_at timestamptz default now(), by_user text, dbg_session text
+);
+
+create table discovery_result (
+  job_id uuid references discovery_job(id) on delete cascade,
+  fingerprint text, addrs inet[], signals text[], confidence real,
+  raw jsonb, primary key (job_id, fingerprint)
+);
+
+-- Secrets/PII are stored via SET™; only encrypted blobs here:
+create table secret_field (
+  id uuid primary key, device_id uuid references device(id),
+  field_name text, ciphertext bytea, iv bytea, aad bytea, ledger_ptr text
+);
+
+create table dbg_session (
+  id uuid primary key, user_id text, dbg_hash bytea, geo jsonb, risk_floor int,
+  created_at timestamptz default now(), expires_at timestamptz
+);
+
+create table ccp_decision (
+  id uuid primary key, actor text, action text, context jsonb,
+  decision text check (decision in ('ALLOW','ESCALATE','LOCK','DENY')),
+  reason text, ledger_hash text, created_at timestamptz default now()
+);
+
+create table hoac_event (
+  id uuid primary key, channel text, profile text check (profile in ('ECC','PQC')),
+  risk int, device_id uuid, transcript bytea, created_at timestamptz default now()
+);

--- a/schemas/crypto.hoac.switches.json
+++ b/schemas/crypto.hoac.switches.json
@@ -1,0 +1,4 @@
+{ "type":"object","properties":{
+  "ts":{"type":"integer"},"device":{"type":"string"},"channel":{"type":"string"},
+  "from":{"enum":["ECC","PQC"]},"to":{"enum":["ECC","PQC"]},"risk":{"type":"integer"}
+},"required":["ts","device","from","to"]}

--- a/schemas/security.ccp.decisions.json
+++ b/schemas/security.ccp.decisions.json
@@ -1,0 +1,5 @@
+{ "type":"object","properties":{
+  "ts":{"type":"integer"},"actor":{"type":"string"},"action":{"type":"string"},
+  "ctx":{"type":"object"},"decision":{"enum":["ALLOW","ESCALATE","LOCK","DENY"]},
+  "reason":{"type":"string"},"ledger":{"type":"string"}
+},"required":["ts","actor","action","decision"]}

--- a/schemas/security.triggers.json
+++ b/schemas/security.triggers.json
@@ -1,0 +1,5 @@
+{ "type":"object","properties":{
+  "ts":{"type":"integer"},"actor":{"type":"string"},"action":{"type":"string"},
+  "decision":{"enum":["ALLOW","ESCALATE","LOCK","DENY"]},"reason":{"type":"string"},
+  "ledger":{"type":"string"}
+},"required":["ts","actor","action","decision"]}

--- a/schemas/telemetry.capsules.json
+++ b/schemas/telemetry.capsules.json
@@ -1,0 +1,4 @@
+{ "type":"object","properties":{
+  "ts":{"type":"integer"},"device":{"type":"string"},"entropy_delta":{"type":"number"},
+  "geo_velocity":{"type":"number"},"behaviour":{"type":"number"},"risk":{"type":"integer"}
+},"required":["ts","device","risk"]}

--- a/schemas/telemetry.features.json
+++ b/schemas/telemetry.features.json
@@ -1,0 +1,7 @@
+{ "type":"object","properties":{
+  "ts":{"type":"integer"},
+  "device":{"type":"string"},
+  "site":{"type":"string"},
+  "loss":{"type":"number"},"lat":{"type":"number"},"jit":{"type":"number"},
+  "entropy_delta":{"type":"number"},"geo_velocity":{"type":"number"}
+},"required":["ts","device"]}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,11 @@
+module "ssfm" {
+  source = "./modules/ssfm"
+  cluster_name = "dv8-sovereign"
+  namespace    = "ssfm"
+  enable_discovery = true
+  enable_ccp       = true
+  enable_quantumshield = true
+  hoac_default_profile = "ECC"
+  hoac_pqc_threshold   = 70
+  aic_capsules         = ["SessionOracle","EntropyGuard","KeySurgeon","VectorMind"]
+}

--- a/terraform/modules/ssfm/README.md
+++ b/terraform/modules/ssfm/README.md
@@ -1,0 +1,3 @@
+# SSFM Module
+
+Placeholder Terraform module for DV8 SS Flow Management deployment.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,163 @@
+import os, sys
+from fastapi.testclient import TestClient
+
+# configure test database
+DB_PATH = os.path.join(os.path.dirname(__file__), "test.db")
+if os.path.exists(DB_PATH):
+    os.remove(DB_PATH)
+os.environ["DATABASE_URL"] = f"sqlite:///{DB_PATH}"
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.db import init_db, SessionLocal, AuditLog  # type: ignore
+from app.main import app  # type: ignore
+
+init_db()
+client = TestClient(app)
+
+
+def test_metrics_endpoint():
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "average_latency" in data
+    assert "status_counts" in data
+    assert len(data["devices"]) == 3
+
+
+def test_dashboard_endpoint():
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    assert "Network Metrics" in resp.text
+
+
+def test_firmware_installation():
+    resp = client.post("/firmware/install", json={"device": "router-1", "version": "1.2.3"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["device"] == "router-1"
+    assert data["version"] == "1.2.3"
+    resp2 = client.get("/firmware/router-1")
+    assert resp2.status_code == 200
+    assert resp2.json()["version"] == "1.2.3"
+    with SessionLocal() as db:
+        assert db.query(AuditLog).filter_by(action="install_firmware").count() == 1
+
+
+def test_sandbox_device_lifecycle():
+    resp = client.post(
+        "/sandbox/device",
+        json={"name": "sim-router", "device_type": "router", "ports": 8},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ports"] == 8
+
+    resp = client.put(
+        "/sandbox/device/sim-router",
+        json={"status": "down", "warnings": {"temperature": True}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "down"
+    assert data["warnings"]["temperature"] is True
+
+    resp = client.get("/sandbox/summary")
+    assert resp.status_code == 200
+    summary = resp.json()
+    assert summary["total_devices"] >= 1
+    assert summary["total_ports"] >= 8
+    assert summary["warning_counts"]["temperature"] >= 1
+
+
+def test_zero_touch_workflow():
+    resp = client.post(
+        "/zero-touch/enroll",
+        json={"name": "ztp-router", "template": "basic-router"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["template"] == "basic-router"
+    assert data["applied"] is False
+
+    resp = client.post("/zero-touch/device/ztp-router/applied")
+    assert resp.status_code == 200
+    assert resp.json()["applied"] is True
+
+    resp = client.get("/zero-touch/devices")
+    assert resp.status_code == 200
+    devices = resp.json()
+    assert any(d["name"] == "ztp-router" for d in devices)
+
+
+def test_autocapture_and_collectors():
+    resp = client.post("/v1/devices/autocapture", json={"serial": "ABC12345"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "hostname" in data and "mgmt_ip" in data
+
+    resp2 = client.get("/v1/vendors/meraki/collectors")
+    assert resp2.status_code == 200
+    assert "collectors" in resp2.json()
+
+
+def test_self_heal_endpoint():
+    client.post('/sandbox/device', json={'name':'heal-router','device_type':'router','ports':4,'status':'down'})
+    resp = client.post('/self-heal')
+    assert resp.status_code == 200
+    assert 'heal-router' in resp.json()['healed']
+
+
+def test_discovery_flow():
+    resp = client.post('/discovery/jobs', json={
+        'tenant': 'tenantA',
+        'scopes': ['site:A'],
+        'cidrs': ['10.0.0.0/24']
+    })
+    assert resp.status_code == 202
+    job_id = resp.json()['id']
+    resp2 = client.get(f'/discovery/jobs/{job_id}')
+    assert resp2.status_code == 200
+    resp3 = client.get('/discovery/candidates', params={'tenant': 'tenantA'})
+    assert resp3.status_code == 200
+
+
+def test_auto_healer_and_guardrail():
+    resp = client.post('/v1/heal/playbooks', json={'name': 'pb', 'triggers': [], 'steps': []})
+    assert resp.status_code == 200
+    pb_id = resp.json()['id']
+    incidents = client.get('/v1/heal/incidents').json()
+    assert any(i['id'] == pb_id for i in incidents)
+    exec_resp = client.post(f'/v1/heal/incidents/{pb_id}/execute')
+    assert exec_resp.status_code == 200
+
+    lint_resp = client.post('/v1/guardrail/lint', json={'intentYaml': 'policy: allow'})
+    assert lint_resp.status_code == 200
+    assert lint_resp.json()['valid'] is True
+    app_resp = client.post('/v1/guardrail/approve', json={'changeId': '1'})
+    assert app_resp.status_code == 200
+
+
+def test_synthetics_and_planner():
+    probe = client.post('/v1/synthetics/probes', json={'intentId': 'i1', 'endpoints': ['a'], 'proto': 'http', 'interval': 10})
+    assert probe.status_code == 200
+    res = client.get('/v1/synthetics/results', params={'intentId': 'i1'})
+    assert res.status_code == 200
+    plan = client.post('/v1/planner/recommend', json={'site': 's1', 'intentId': 'i1', 'horizonDays': 5})
+    assert plan.status_code == 200
+
+
+def test_compliance_vuln_pathtracer():
+    scan = client.post('/v1/compliance/scans', json={'profile': 'DISA', 'scope': {}})
+    assert scan.status_code == 200
+    res = client.get('/v1/compliance/results', params={'profile': 'DISA', 'device': 'router-1'})
+    assert res.status_code == 200
+
+    sync = client.post('/v1/vulnwatch/sync')
+    assert sync.status_code == 200
+    findings = client.get('/v1/vulnwatch/findings', params={'device': 'router-1'})
+    assert findings.status_code == 200
+
+    path = client.get('/v1/sdwan/pathtracer', params={'src': 'a', 'dst': 'b'})
+    assert path.status_code == 200
+    impact = client.get('/v1/policy/impact', params={'policyId': 'p1', 'before': 'old', 'after': 'new'})
+    assert impact.status_code == 200

--- a/yang/dv8-flowos.yang
+++ b/yang/dv8-flowos.yang
@@ -1,0 +1,9 @@
+module dv8-flowos {
+  namespace "urn:dv8:flowos"; prefix fos;
+  container discovery {
+    leaf enabled { type boolean; default true; }
+    leaf passive-only { type boolean; default false; }
+    leaf rate-limit-pps { type uint32; default 100; }
+    list cidr-allowlist { key "cidr"; leaf cidr { type string; } }
+  }
+}

--- a/yang/dv8-quantumshield.yang
+++ b/yang/dv8-quantumshield.yang
@@ -1,0 +1,15 @@
+module dv8-quantumshield {
+  namespace "urn:dv8:qs"; prefix qs;
+  container qs {
+    leaf pqc-required { type boolean; default false; }
+    container dbg { leaf enabled { type boolean; default true; } }
+    list set-field {
+      key "name";
+      leaf name { type string; }
+      leaf aead { type enumeration { enum AES256_GCM; } }
+      leaf aad-policy { type string; }
+    }
+    container hoac { leaf profile { type enumeration { enum ECC; enum PQC; } default ECC; } }
+    container lso { leaf exports { type boolean; default false; } }
+  }
+}


### PR DESCRIPTION
## Summary
- add compliance and vulnerability watch endpoints to console
- expose SD-WAN path tracer and policy impact APIs
- mirror new features in ASP.NET Core service with unit tests
- document global error handling across Python and .NET services

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `cd dotnet && dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b440180c83289972ccc1f073bf7e